### PR TITLE
add support for password encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,4 @@ Parameter | Type | User Property | Required | Description
 `<uploadRepoStable>`| [HelmRepository](./src/main/java/com/kiwigrid/helm/maven/plugin/HelmRepository.java) | helm.uploadRepo.stable | true | Upload repository for stable charts
 `<uploadRepoSnapshot>`| [HelmRepository](./src/main/java/com/kiwigrid/helm/maven/plugin/HelmRepository.java) | helm.uploadRepo.snapshot | false | Upload repository for snapshot charts (determined by version postfix 'SNAPSHOT')
 `<skipRefresh>` | boolean | helm.init.skipRefresh | false | do not refresh (download) the local repository cache while init
+`<security>` | string | helm.security | false | path to your [settings-security.xml](https://maven.apache.org/guides/mini/guide-encryption.html) (default: `~/.m2/settings-security.xml`)

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.1.0</version>
+			</plugin>			
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.19.1</version>
 				<configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,11 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.sonatype.plexus</groupId>
+			<artifactId>plexus-sec-dispatcher</artifactId>
+			<version>1.4</version>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<version>5.0.2</version>

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
@@ -229,7 +229,7 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 		}
 	}
 	
-	private SecDispatcher getSecDispatcher() {
+	protected SecDispatcher getSecDispatcher() {
 		if (securityDispatcher instanceof DefaultSecDispatcher) {
 			((DefaultSecDispatcher)securityDispatcher).setConfigurationFile(getHelmSecurity());
 		}

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
@@ -11,14 +11,19 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.kiwigrid.helm.maven.plugin.pojo.HelmRepository;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
+import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher;
+import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
+import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
+
+import com.kiwigrid.helm.maven.plugin.pojo.HelmRepository;
 
 /**
  * Base class for mojos
@@ -28,6 +33,9 @@ import org.apache.maven.settings.Settings;
  */
 public abstract class AbstractHelmMojo extends AbstractMojo {
 
+	@Component( role = org.sonatype.plexus.components.sec.dispatcher.SecDispatcher.class, hint = "default" )
+	private SecDispatcher securityDispatcher;
+    
 	@Parameter(property = "helm.executableDirectory", defaultValue = "${project.build.directory}/helm")
 	private String helmExecuteableDirectory;
 
@@ -66,6 +74,9 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 
 	@Parameter(property = "helm.extraRepos")
 	private HelmRepository[] helmExtraRepos;
+	
+	@Parameter(property = "helm.security", defaultValue = "~/.m2/settings-security.xml")
+	private String helmSecurity;
 
 	/**
 	 * The current user system settings for use in Maven.
@@ -186,8 +197,9 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 	 * @param repository Helm repo with id and optional credentials.
 	 * @return Authentication object or <code>null</code> if no credentials are present.
 	 * @throws IllegalArgumentException Unable to get authentication because of misconfiguration.
+	 * @throws MojoExecutionException Unable to get password from settings.xml
 	 */
-	PasswordAuthentication getAuthentication(HelmRepository repository) throws IllegalArgumentException {
+	PasswordAuthentication getAuthentication(HelmRepository repository) throws IllegalArgumentException, MojoExecutionException {
 		String id = repository.getName();
 
 		if (repository.getUsername() != null) {
@@ -208,7 +220,20 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 		if (server.getUsername() == null || server.getPassword() == null) {
 			throw new IllegalArgumentException("Repo " + id + " was found in server list but has no username/password.");
 		}
-		return new PasswordAuthentication(server.getUsername(), server.getPassword().toCharArray());
+		
+		try {
+			return new PasswordAuthentication(server.getUsername(), getSecDispatcher().decrypt( server.getPassword() ).toCharArray());
+		}
+		catch ( SecDispatcherException e ) {
+			throw new MojoExecutionException( e.getMessage() );
+		}
+	}
+	
+	private SecDispatcher getSecDispatcher() {
+		if (securityDispatcher instanceof DefaultSecDispatcher) {
+			((DefaultSecDispatcher)securityDispatcher).setConfigurationFile(getHelmSecurity());
+		}
+		return securityDispatcher;
 	}
 
 	public String getHelmExecuteable() {
@@ -305,6 +330,14 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 
 	public void setUploadRepoSnapshot(HelmRepository uploadRepoSnapshot) {
 		this.uploadRepoSnapshot = uploadRepoSnapshot;
+	}
+
+	public String getHelmSecurity() {
+		return helmSecurity;
+	}
+
+	public void setHelmSecurity(String helmSecurity) {
+		this.helmSecurity = helmSecurity;
 	}
 
 	public Settings getSettings() {

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/UploadMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/UploadMojo.java
@@ -41,7 +41,7 @@ public class UploadMojo extends AbstractHelmMojo {
 		}
 	}
 
-	private void uploadSingle(String file) throws IOException, BadUploadException {
+	private void uploadSingle(String file) throws IOException, BadUploadException, MojoExecutionException {
 		final File fileToUpload = new File(file);
 		final HelmRepository uploadRepo = getHelmUploadRepo();
 
@@ -84,7 +84,7 @@ public class UploadMojo extends AbstractHelmMojo {
 		return connection;
 	}
 
-	protected HttpURLConnection getConnectionForUploadToArtifactory(File file) throws IOException {
+	protected HttpURLConnection getConnectionForUploadToArtifactory(File file) throws IOException, MojoExecutionException {
 		String uploadUrl = getHelmUploadUrl();
 		// Append slash if not already in place
 		if (!uploadUrl.endsWith("/")) {
@@ -102,7 +102,7 @@ public class UploadMojo extends AbstractHelmMojo {
 		return connection;
 	}
 
-	private void verifyAndSetAuthentication() {
+	private void verifyAndSetAuthentication() throws MojoExecutionException {
 
 		PasswordAuthentication authentication = getAuthentication(getHelmUploadRepo());
 		if (authentication == null) {

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/UploadMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/UploadMojoTest.java
@@ -49,7 +49,7 @@ public class UploadMojoTest {
 	}
 
 	@Test
-	public void verifyHttpConnectionForArtifactoryUpload(UploadMojo uploadMojo) throws IOException {
+	public void verifyHttpConnectionForArtifactoryUpload(UploadMojo uploadMojo) throws IOException, MojoExecutionException {
 		final URL resource = this.getClass().getResource("app-0.1.0.tgz");
 		final File fileToUpload = new File(resource.getFile());
 

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/UploadMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/UploadMojoTest.java
@@ -4,7 +4,10 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.Authenticator;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -16,6 +19,7 @@ import com.kiwigrid.helm.maven.plugin.junit.SystemPropertyExtension;
 import com.kiwigrid.helm.maven.plugin.pojo.HelmRepository;
 import com.kiwigrid.helm.maven.plugin.pojo.RepoType;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.settings.Server;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -46,6 +50,86 @@ public class UploadMojoTest {
 		doReturn(tgzs).when(mojo).getChartTgzs(anyString());
 
 		assertThrows(IllegalArgumentException.class, mojo::execute, "Missing credentials must fail.");
+	}
+	
+	@Test
+	public void uploadToArtifactoryWithRepositoryCredentials(UploadMojo mojo) throws IOException, MojoExecutionException {
+		final HelmRepository helmRepo = new HelmRepository();
+		helmRepo.setType(RepoType.ARTIFACTORY);
+		helmRepo.setName("my-artifactory");
+		helmRepo.setUrl("https://somwhere.com/repo");
+		helmRepo.setUsername("foo");
+		helmRepo.setPassword("bar");
+		mojo.setUploadRepoStable(helmRepo);		
+		
+		final URL resource = this.getClass().getResource("app-0.1.0.tgz");
+		final File fileToUpload = new File(resource.getFile());
+		final List<String> tgzs = new ArrayList<>();
+		tgzs.add(resource.getFile());
+		
+		doReturn(helmRepo).when(mojo).getHelmUploadRepo();
+		doReturn(tgzs).when(mojo).getChartTgzs(anyString());
+		
+		assertNotNull(mojo.getConnectionForUploadToArtifactory(fileToUpload));
+	}
+	
+	@Test
+	public void uploadToArtifactoryWithPlainCredentialsFromSettings(UploadMojo mojo) throws IOException, MojoExecutionException {
+		final Server server = new Server();
+		server.setId("my-artifactory");
+		server.setUsername("foo");
+		server.setPassword("bar");
+		final List<Server> servers = new ArrayList<>();
+		servers.add(server);
+		mojo.getSettings().setServers(servers);
+		
+		final HelmRepository helmRepo = new HelmRepository();
+		helmRepo.setType(RepoType.ARTIFACTORY);
+		helmRepo.setName("my-artifactory");
+		helmRepo.setUrl("https://somwhere.com/repo");
+		mojo.setUploadRepoStable(helmRepo);		
+		
+		final URL resource = this.getClass().getResource("app-0.1.0.tgz");
+		final File fileToUpload = new File(resource.getFile());
+		final List<String> tgzs = new ArrayList<>();
+		tgzs.add(resource.getFile());
+
+		doReturn(helmRepo).when(mojo).getHelmUploadRepo();
+		doReturn(tgzs).when(mojo).getChartTgzs(anyString());
+
+		assertNotNull(mojo.getConnectionForUploadToArtifactory(fileToUpload));
+	}
+	
+	@Test
+	public void uploadToArtifactoryWithEncryptedCredentialsFromSettings(UploadMojo mojo) throws IOException, MojoExecutionException {
+		final Server server = new Server();
+		server.setId("my-artifactory");
+		server.setUsername("foo");
+		server.setPassword("{GGhJc6qP+v0Hg2l+dei1MQFZt/55PzyFXY0MUMxcQdQ=}");
+		final List<Server> servers = new ArrayList<>();
+		servers.add(server);
+		mojo.getSettings().setServers(servers);
+		
+		final HelmRepository helmRepo = new HelmRepository();
+		helmRepo.setType(RepoType.ARTIFACTORY);
+		helmRepo.setName("my-artifactory");
+		helmRepo.setUrl("https://somwhere.com/repo");
+		mojo.setUploadRepoStable(helmRepo);		
+		
+		final URL resource = this.getClass().getResource("app-0.1.0.tgz");
+		final File fileToUpload = new File(resource.getFile());
+		final List<String> tgzs = new ArrayList<>();
+		tgzs.add(resource.getFile());
+
+		doReturn(this.getClass().getResource("settings-security.xml").getFile()).when(mojo).getHelmSecurity();
+		doReturn(helmRepo).when(mojo).getHelmUploadRepo();
+		doReturn(tgzs).when(mojo).getChartTgzs(anyString());
+		
+		assertNotNull(mojo.getConnectionForUploadToArtifactory(fileToUpload));
+
+		final PasswordAuthentication pwd = Authenticator.requestPasswordAuthentication(InetAddress.getLocalHost(), 443, "https", "", "basicauth");
+		assertEquals("foo", pwd.getUserName());
+		assertEquals("bar", String.valueOf(pwd.getPassword()));
 	}
 
 	@Test

--- a/src/test/resources/com/kiwigrid/helm/maven/plugin/settings-security.xml
+++ b/src/test/resources/com/kiwigrid/helm/maven/plugin/settings-security.xml
@@ -1,0 +1,3 @@
+<settingsSecurity>
+	<master>{oZOeykV6dUEHOIJI2zrK2nLfgywVyH3WpEV7keW8orI=}</master>
+</settingsSecurity>


### PR DESCRIPTION
It is possible to encrypt the repository password in the settings.xml, see https://maven.apache.org/guides/mini/guide-encryption.html. Before passing the password to the http PasswordAuthentication it has to be decrypted using the master password. The Maven SecDispatcher checks whether or not the password is encrypted and decrypts it if necessary.