### PR TITLE
fixed typo in helm executable directory property

### DIFF
--- a/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
@@ -29,7 +29,7 @@ import org.apache.maven.settings.Settings;
 public abstract class AbstractHelmMojo extends AbstractMojo {
 
 	@Parameter(property = "helm.executableDirectory", defaultValue = "${project.build.directory}/helm")
-	private String helmExecuteableDirectory;
+	private String helmExecutableDirectory;
 
 	/**
 	 * If no executeable is set this plugin tries to determine helm executeable based on operation system.
@@ -77,7 +77,7 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 		if (helmExecuteable == null) {
 			helmExecuteable = SystemUtils.IS_OS_WINDOWS ? "helm.exe" : "helm";
 		}
-		Path path = Paths.get(helmExecuteableDirectory, helmExecuteable).toAbsolutePath();
+		Path path = Paths.get(helmExecutableDirectory, helmExecuteable).toAbsolutePath();
 		if (!path.toFile().exists()) {
 			throw new MojoExecutionException("Helm executeable at " + path + " not found.");
 		}
@@ -227,12 +227,12 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 		this.outputDirectory = outputDirectory;
 	}
 
-	public String getHelmExecuteableDirectory() {
-		return helmExecuteableDirectory;
+	public String getHelmExecutableDirectory() {
+		return helmExecutableDirectory;
 	}
 
-	public void setHelmExecuteableDirectory(String helmExecuteableDirectory) {
-		this.helmExecuteableDirectory = helmExecuteableDirectory;
+	public void setHelmExecutableDirectory(String helmExecuteableDirectory) {
+		this.helmExecutableDirectory = helmExecuteableDirectory;
 	}
 
 	public String getHelmDownloadUrl() {

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
@@ -31,20 +31,20 @@ public class InitMojo extends AbstractHelmMojo {
 				false);
 		getLog().info("Downloading Helm...");
 		callCli("wget -qO "
-						+ getHelmExecuteableDirectory()
+						+ getHelmExecutableDirectory()
 						+ File.separator
 						+ "helm.tar.gz "
 						+ getHelmDownloadUrl(),
 				"Unable to download helm", false);
 		getLog().info("Unpacking Helm...");
 		callCli("tar -xf "
-				+ getHelmExecuteableDirectory()
+				+ getHelmExecutableDirectory()
 				+ File.separator
 				// flatten directory structure using --strip to get helm executeable on basedir, see https://www.systutorials.com/docs/linux/man/1-tar/#lbAS
 				+ "helm.tar.gz --strip=1 --directory="
-				+ getHelmExecuteableDirectory(), "Unable to unpack helm to " + getHelmExecuteableDirectory(), false);
+				+ getHelmExecutableDirectory(), "Unable to unpack helm to " + getHelmExecutableDirectory(), false);
 		getLog().info("Run helm init...");
-		callCli(getHelmExecuteableDirectory()
+		callCli(getHelmExecutableDirectory()
 						+ File.separator
 						+ "helm init --client-only" + (skipRefresh ? " --skip-refresh" : "")
 						+ (StringUtils.isNotEmpty(getHelmHomeDirectory()) ? " --home=" + getHelmHomeDirectory() : ""),
@@ -55,7 +55,7 @@ public class InitMojo extends AbstractHelmMojo {
 			for (HelmRepository repository : getHelmExtraRepos()) {
 				getLog().info("Adding repo " + repository);
 				PasswordAuthentication auth = getAuthentication(repository);
-				callCli(getHelmExecuteableDirectory()
+				callCli(getHelmExecutableDirectory()
 								+ File.separator
 								+ "helm repo add "
 								+ repository.getName()

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
@@ -42,7 +42,7 @@ public class InitMojoTest {
 
 		// check helm file
 
-		Path helm = Paths.get(mojo.getHelmExecuteableDirectory(), "windows".equals(os) ? "helm.exe" : "helm")
+		Path helm = Paths.get(mojo.getHelmExecutableDirectory(), "windows".equals(os) ? "helm.exe" : "helm")
 				.toAbsolutePath();
 		assertTrue(Files.exists(helm), "Helm executable not found at: " + helm);
 	}


### PR DESCRIPTION
Fixed a typo in the field name for the Helm executable directory. This is the property name you have to use in your pom.xml:

```xml
<configuration>
  <helmExecuteableDirectory></helmExecuteableDirectory>
</configuration>
```
