### PR TITLE
Custom packaging for helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ To keep your pom files small you can use 'helm' packaging. This binds `helm:init
       <plugin>
         <groupId>com.kiwigrid</groupId>
         <artifactId>helm-maven-plugin</artifactId>
+        <!-- Mandatory when you use a custom lifecycle -->
         <extensions>true</extensions>
         <configuration>
           ...
@@ -179,5 +180,3 @@ To keep your pom files small you can use 'helm' packaging. This binds `helm:init
   </build>
 </pom>
 ```
-
-Please note the `<extensions>true</extensions>` which is mandatory when you use a custom lifecycle.

--- a/README.md
+++ b/README.md
@@ -152,3 +152,31 @@ Parameter | Type | User Property | Required | Description
 `<uploadRepoStable>`| [HelmRepository](./src/main/java/com/kiwigrid/helm/maven/plugin/HelmRepository.java) | helm.uploadRepo.stable | true | Upload repository for stable charts
 `<uploadRepoSnapshot>`| [HelmRepository](./src/main/java/com/kiwigrid/helm/maven/plugin/HelmRepository.java) | helm.uploadRepo.snapshot | false | Upload repository for snapshot charts (determined by version postfix 'SNAPSHOT')
 `<skipRefresh>` | boolean | helm.init.skipRefresh | false | do not refresh (download) the local repository cache while init
+
+## Packaging with the helm lifecycle
+
+To keep your pom files small you can use 'helm' packaging. This binds `helm:init` to the initialize phase, `helm:lint` to the test phase, `helm:package` to the package phase and `helm:upload` to the deploy phase.
+
+```xml
+<pom>
+  <artifactId>my-helm-charts</artifactId>
+  <version>0.0.1</version>
+  <packaging>helm</packaging>
+  ...
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.kiwigrid</groupId>
+        <artifactId>helm-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          ...
+        </configuration>
+      </plugin>
+    </plugins>
+    ....
+  </build>
+</pom>
+```
+
+Please note the `<extensions>true</extensions>` which is mandatory when you use a custom lifecycle.

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,23 @@
+<component-set>
+	<components>
+		<component>
+			<role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+			<role-hint>helm</role-hint>
+			<implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping
+			</implementation>
+			<configuration>
+				<lifecycles>
+					<lifecycle>
+						<id>default</id>
+						<phases>
+							<initialize>com.kiwigrid:helm-maven-plugin:init</initialize>
+							<test>com.kiwigrid:helm-maven-plugin:lint</test>
+							<package>com.kiwigrid:helm-maven-plugin:package</package>
+							<deploy>com.kiwigrid:helm-maven-plugin:upload</deploy>
+						</phases>
+					</lifecycle>
+				</lifecycles>
+			</configuration>
+		</component>
+	</components>
+</component-set>


### PR DESCRIPTION
Added a lifecycle for custom packaging of Helm charts which binds a couple of plugin goals to the Maven lifecycle. This cleans up the plugin execution definitions in your own project pom.