### PR TITLE
Auto detect helm executable from PATH by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Add following dependency to your pom.xml:
 ```
 
 ### Usage with Local Binary
+
+When `useLocalHelmBinary` is enabled, the plugin by default will search for the `helm` executable in `PATH`:
+
 ```xml
 <build>
   <plugins>
@@ -66,8 +69,32 @@ Add following dependency to your pom.xml:
       <configuration>
         <chartDirectory>${project.basedir}</chartDirectory>
         <chartVersion>${project.version}</chartVersion>
-        <!-- This is the related section to use local binary -->
+        <!-- This is the related section to use local binary with auto-detection enabled. -->
         <useLocalHelmBinary>true</useLocalHelmBinary>
+      </configuration>
+    </plugin>
+  ...
+  </plugins>
+</build>
+```
+
+The following is an example configuration that explicitly sets the directory in which to look for the `helm` executable,
+and disables the auto-detection feature:
+
+```xml
+<build>
+  <plugins>
+  ...
+    <plugin>
+      <groupId>com.kiwigrid</groupId>
+      <artifactId>helm-maven-plugin</artifactId>
+      <version>4.0</version>
+      <configuration>
+        <chartDirectory>${project.basedir}</chartDirectory>
+        <chartVersion>${project.version}</chartVersion>
+        <!-- This is the related section to use local binary with auto-detection disabled. -->
+        <useLocalHelmBinary>true</useLocalHelmBinary>
+        <autoDetectLocalHelmBinary>false</autoDetectLocalHelmBinary>
         <helmExecutableDirectory>/usr/local/bin</helmExecutableDirectory>        
       </configuration>
     </plugin>

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Parameter | Type | User Property | Required | Description
 `<helmDownloadUrl>` | string | helm.downloadUrl | false | URL to download helm
 `<excludes>` | list of strings | helm.excludes | false | list of chart directories to exclude
 `<useLocalHelmBinary>` | boolean | helm.useLocalHelmBinary | false | Controls whether a local binary should be used instead of downloading it. If set to `true` path has to be set with property `executableDirectory`
+`<autoDetectLocalHelmBinary>` | boolean | helm.autoDetectLocalHelmBinary | true | Controls whether the local binary should be auto-detected from `PATH` environment variable. If set to `false` the binary in `<helmExecutableDirectory>` is used. This property has no effect unless `<useLocalHelmBinary>` is set to `true`.
 `<helmExecutableDirectory>` | string | helm.executableDirectory | false | directory of your helm installation (default: `${project.build.directory}/helm`)
 `<outputDirectory>` | string | helm.outputDirectory | false | chart output directory (default: `${project.build.directory}/helm/repo`)
 `<helmHomeDirectory>` | string | helm.homeDirectory | false | path to helm home directory; useful for concurrent Jenkins builds! (default: `~/.helm`)

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojoTest.java
@@ -48,8 +48,8 @@ class AbstractHelmMojoTest {
         @Test
         void helmIsAutoDetectedFromPATH() throws MojoExecutionException, IOException {
 
-            final Path actualHelmPath = addHelmToTestPath();
-            assertEquals(actualHelmPath, subjectSpy.getHelmExecuteablePath());
+            final Path expectedPath = addHelmToTestPath();
+            assertEquals(expectedPath, subjectSpy.getHelmExecuteablePath());
         }
 
         @Test
@@ -64,8 +64,8 @@ class AbstractHelmMojoTest {
 
             final String explicitExecutableDirectory = "/fish/in/da/sea";
             subjectSpy.setHelmExecutableDirectory(explicitExecutableDirectory);
-            final Path actualHelmPath = addHelmToTestPath();
-            assertEquals(actualHelmPath, subjectSpy.getHelmExecuteablePath());
+            final Path expectedPath = addHelmToTestPath();
+            assertEquals(expectedPath, subjectSpy.getHelmExecuteablePath());
             assertNotEquals(explicitExecutableDirectory, subjectSpy.getHelmExecuteablePath());
         }
     }
@@ -83,8 +83,8 @@ class AbstractHelmMojoTest {
         @Test
         void helmIsInTheExplicitlyConfiguredDirectory() throws MojoExecutionException, IOException {
 
-            final Path actualHelmPath = addHelmToTestPath();
-            assertEquals(actualHelmPath, subjectSpy.getHelmExecuteablePath());
+            final Path expectedPath = addHelmToTestPath();
+            assertEquals(expectedPath, subjectSpy.getHelmExecuteablePath());
         }
 
         @Test

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojoTest.java
@@ -1,0 +1,108 @@
+package com.kiwigrid.helm.maven.plugin;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.file.Files.write;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+
+class AbstractHelmMojoTest {
+
+    private NoopHelmMojo subjectSpy;
+    private Path testPath;
+    private Path testHelmExecutablePath;
+
+    @BeforeEach
+    void setUp() throws IOException {
+
+        subjectSpy = Mockito.spy(new NoopHelmMojo());
+        testPath = Files.createTempDirectory("test").toAbsolutePath();
+        testHelmExecutablePath = testPath.resolve(SystemUtils.IS_OS_WINDOWS ? "helm.exe" : "helm");
+    }
+
+    @Nested
+    class WhenUseLocalBinaryAndAutoDetectIsEnabled {
+
+        @BeforeEach
+        void setUp() {
+
+            subjectSpy.setUseLocalHelmBinary(true);
+            subjectSpy.setAutoDetectLocalHelmBinary(true);
+            doReturn(new String[]{ testPath.toAbsolutePath().toString() }).when(subjectSpy).getPathsFromEnvironmentVariables();
+        }
+
+        @Test
+        void helmIsAutoDetectedFromPATH() throws MojoExecutionException, IOException {
+
+            final Path actualHelmPath = addHelmToTestPath();
+            assertEquals(actualHelmPath, subjectSpy.getHelmExecuteablePath());
+        }
+
+        @Test
+        void executionFailsWhenHelmIsNotFoundInPATH() {
+
+            final MojoExecutionException exception = assertThrows(MojoExecutionException.class, subjectSpy::getHelmExecuteablePath);
+            assertTrue(exception.getMessage().contains("not found"));
+        }
+
+        @Test
+        void helmIsAutoDetectedEvenWhenExecutableDirectoryIsConfigured() throws IOException, MojoExecutionException {
+
+            final String explicitExecutableDirectory = "/fish/in/da/sea";
+            subjectSpy.setHelmExecutableDirectory(explicitExecutableDirectory);
+            final Path actualHelmPath = addHelmToTestPath();
+            assertEquals(actualHelmPath, subjectSpy.getHelmExecuteablePath());
+            assertNotEquals(explicitExecutableDirectory, subjectSpy.getHelmExecuteablePath());
+        }
+    }
+
+    @Nested
+    class WhenExecutableDirectoryIsSpecifiedAndUseLocalBinaryIsDisabled {
+
+        @BeforeEach
+        void setUp() {
+
+            subjectSpy.setUseLocalHelmBinary(false);
+            subjectSpy.setHelmExecutableDirectory(testPath.toString());
+        }
+
+        @Test
+        void helmIsInTheExplicitlyConfiguredDirectory() throws MojoExecutionException, IOException {
+
+            final Path actualHelmPath = addHelmToTestPath();
+            assertEquals(actualHelmPath, subjectSpy.getHelmExecuteablePath());
+        }
+
+        @Test
+        void executionFailsWhenHelmIsNotFoundInConfiguredDirectory() {
+
+            final MojoExecutionException exception = assertThrows(MojoExecutionException.class, subjectSpy::getHelmExecuteablePath);
+            assertTrue(exception.getMessage().contains("not found"));
+        }
+    }
+
+    private Path addHelmToTestPath() throws IOException { return write(testHelmExecutablePath, new byte[]{}); }
+
+    @AfterEach
+    void tearDown() { deleteQuietly(testPath.toFile()); }
+
+    private static class NoopHelmMojo extends AbstractHelmMojo {
+
+        @Override
+        public void execute() { /* Noop. */ }
+    }
+}

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
 
@@ -108,6 +109,9 @@ public class InitMojoTest {
 		mojo.setHelmExecutableDirectory(helmExecutableDir);
 
 		// execute
+		assumeTrue(isOSUnix()); // Because the download URL is hardcoded to linux, only proceed if the OS is indeed linux.
 		mojo.execute();
 	}
+
+	private boolean isOSUnix() { return System.getProperty("os.name").matches(".*n[i|u]x.*"); }
 }


### PR DESCRIPTION
- [x] Add option to auto-detect `helm` from `PATH` if `useLocalHelmBinary` is enabled.
- [x] Fix an issue with OS-specific test; see https://github.com/kiwigrid/helm-maven-plugin/pull/39/commits/aa4dfb526f8020f7b7fbd5ab4cfeb1d5ee331768

See #38 