### PR TITLE
Also run helm init when using local binary

### DIFF
--- a/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
@@ -125,23 +125,11 @@ public class InitMojo extends AbstractHelmMojo {
 			throw new MojoExecutionException("Unable to find helm executable in tar file.");
 		}
 
-		getLog().info("Run helm init...");
-		callCli(getHelmExecutableDirectory()
-						+ File.separator
-						+ "helm init --client-only" + (skipRefresh ? " --skip-refresh" : "")
-						+ (StringUtils.isNotEmpty(getHelmHomeDirectory()) ? " --home=" + getHelmHomeDirectory() : ""),
-				"Unable to call helm init",
-				false);
+		initHelmClient();
 	}
 
 	private void verifyLocalHelmBinary() throws MojoExecutionException {
-		getLog().info("Run helm init...");
-		callCli(getHelmExecutableDirectory()
-						+ File.separator
-						+ "helm init --client-only" + (skipRefresh ? " --skip-refresh" : "")
-						+ (StringUtils.isNotEmpty(getHelmHomeDirectory()) ? " --home=" + getHelmHomeDirectory() : ""),
-				"Unable to call helm init",
-				false);
+		initHelmClient();
 		callCli(getHelmExecuteablePath() + " version --client", "Unable to verify local HELM binary", false);
 	}
 
@@ -151,5 +139,15 @@ public class InitMojo extends AbstractHelmMojo {
 
 	public void setSkipRefresh(boolean skipRefresh) {
 		this.skipRefresh = skipRefresh;
+	}
+
+	private void initHelmClient() throws MojoExecutionException {
+		getLog().info("Run helm init...");
+		callCli(getHelmExecutableDirectory()
+						+ File.separator
+						+ "helm init --client-only" + (skipRefresh ? " --skip-refresh" : "")
+						+ (StringUtils.isNotEmpty(getHelmHomeDirectory()) ? " --home=" + getHelmHomeDirectory() : ""),
+				"Unable to call helm init",
+				false);
 	}
 }

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
@@ -135,6 +135,13 @@ public class InitMojo extends AbstractHelmMojo {
 	}
 
 	private void verifyLocalHelmBinary() throws MojoExecutionException {
+		getLog().info("Run helm init...");
+		callCli(getHelmExecutableDirectory()
+						+ File.separator
+						+ "helm init --client-only" + (skipRefresh ? " --skip-refresh" : "")
+						+ (StringUtils.isNotEmpty(getHelmHomeDirectory()) ? " --home=" + getHelmHomeDirectory() : ""),
+				"Unable to call helm init",
+				false);
 		callCli(getHelmExecuteablePath() + " version --client", "Unable to verify local HELM binary", false);
 	}
 


### PR DESCRIPTION
Also when using the local binary the command `helm init --client-only` should be called to ensure that helm is properly initialized as otherwise package will fail if not

There is no harm when running command on an already initialized helm
```bash
~# helm init --client-only
$HELM_HOME has been configured at /home/jenkins/.helm.
Not installing Tiller due to 'client-only' flag having been set
Happy Helming!
```