### PR TITLE
fix #48 - Init stage fails if auto-detect helm binary is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 target/
 .idea/
+.attach_pid*

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
@@ -145,8 +145,7 @@ public class InitMojo extends AbstractHelmMojo {
 		getLog().info("Run helm init...");
 
 		callCli(getHelmExecuteablePath()
-						+ File.separator
-						+ "helm init --client-only" + (skipRefresh ? " --skip-refresh" : "")
+						+ " init --client-only" + (skipRefresh ? " --skip-refresh" : "")
 						+ (StringUtils.isNotEmpty(getHelmHomeDirectory()) ? " --home=" + getHelmHomeDirectory() : ""),
 				"Unable to call helm init",
 				false);

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
@@ -129,8 +129,8 @@ public class InitMojo extends AbstractHelmMojo {
 	}
 
 	private void verifyLocalHelmBinary() throws MojoExecutionException {
-		initHelmClient();
 		callCli(getHelmExecuteablePath() + " version --client", "Unable to verify local HELM binary", false);
+		initHelmClient();
 	}
 
 	public boolean isSkipRefresh() {
@@ -143,7 +143,8 @@ public class InitMojo extends AbstractHelmMojo {
 
 	private void initHelmClient() throws MojoExecutionException {
 		getLog().info("Run helm init...");
-		callCli(getHelmExecutableDirectory()
+
+		callCli(getHelmExecuteablePath()
 						+ File.separator
 						+ "helm init --client-only" + (skipRefresh ? " --skip-refresh" : "")
 						+ (StringUtils.isNotEmpty(getHelmHomeDirectory()) ? " --home=" + getHelmHomeDirectory() : ""),

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 
 @ExtendWith({ SystemPropertyExtension.class, MojoExtension.class })
 @MojoProperty(name = "helmDownloadUrl", value = "https://kubernetes-helm.storage.googleapis.com/helm-v2.9.1-linux-amd64.tar.gz")
@@ -37,7 +38,10 @@ public class InitMojoTest {
 
 		// prepare execution
 		doNothing().when(mojo).callCli(contains("helm "), anyString(), anyBoolean());
-		mojo.setHelmDownloadUrl("https://kubernetes-helm.storage.googleapis.com/helm-v2.9.1-" + os + "-amd64.tar.gz");
+		// getHelmExecuteablePath is system-depending and has to be mocked for that reason
+		// as SystemUtils.IS_OS_WINDOWS will always return false on a *NIX system
+		doReturn(Paths.get("dummy/path/to/helm").toAbsolutePath()).when(mojo).getHelmExecuteablePath();
+		mojo.setHelmDownloadUrl("https://kubernetes-helm.storage.googleapis.com/helm-v2.14.1-" + os + "-amd64.tar.gz");
 
 		// run init
 		mojo.execute();


### PR DESCRIPTION
By the use of `helm init` for both local and non-local binary the method shall use `getHelmExecuteablePath()` instead of `getHelmExecutableDirectory()` as the `helm.executableDirectory` may not be set when using local binary