### PR TITLE
Accept success codes only while uploading to http

### DIFF
--- a/src/main/java/com/kiwigrid/helm/maven/plugin/UploadMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/UploadMojo.java
@@ -73,7 +73,7 @@ public class UploadMojo extends AbstractHelmMojo {
 		try (FileInputStream fileInputStream = new FileInputStream(fileToUpload)) {
 			IOUtils.copy(fileInputStream, connection.getOutputStream());
 		}
-		if (connection.getResponseCode() >= 400) {
+		if (connection.getResponseCode() >= 300) {
 			String response = IOUtils.toString(connection.getErrorStream(), Charset.defaultCharset());
 			throw new BadUploadException(response);
 		} else {


### PR DESCRIPTION
Following redirects is not safe solution, see https://stackoverflow.com/questions/1884230/urlconnection-doesnt-follow-redirect

https://github.com/kiwigrid/helm-maven-plugin/issues/52