### PR TITLE
Migrate to Helm3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Currently the upload to [ChartMuseum](https://github.com/kubernetes-helm/chartmu
 
 [![Build Status](https://travis-ci.org/kiwigrid/helm-maven-plugin.svg?branch=master)](https://travis-ci.org/kiwigrid/helm-maven-plugin)
 
+## Helm v3
+
+From version **5.0** Helm v3 is required.
+There is no longer support for Helm v2.
+For convenience reasons the stable repo is added by default.
+
 # Why?
 
 Currently (October 2017) there is no simple Maven plugin to package existing HELM charts.
@@ -26,7 +32,7 @@ Add following dependency to your pom.xml:
 <dependency>
   <groupId>com.kiwigrid</groupId>
   <artifactId>helm-maven-plugin</artifactId>
-  <version>4.13</version>
+  <version>5.0</version>
 </dependency>
 ```
 
@@ -40,13 +46,12 @@ Add following dependency to your pom.xml:
     <plugin>
       <groupId>com.kiwigrid</groupId>
       <artifactId>helm-maven-plugin</artifactId>
-      <version>4.13</version>
+      <version>5.0</version>
       <configuration>
         <chartDirectory>${project.basedir}</chartDirectory>
         <chartVersion>${project.version}</chartVersion>
         <!-- This is the related section when using binary download -->
-        <helmDownloadUrl>https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz</helmDownloadUrl>
-        <helmHomeDirectory>${project.basedir}/target/helm/home</helmHomeDirectory>
+        <helmDownloadUrl>https://get.helm.sh/helm-v3.0.0-linux-amd64.tar.gz</helmDownloadUrl>
       </configuration>
     </plugin>
   ...
@@ -65,7 +70,7 @@ When `useLocalHelmBinary` is enabled, the plugin by default will search for the 
     <plugin>
       <groupId>com.kiwigrid</groupId>
       <artifactId>helm-maven-plugin</artifactId>
-      <version>4.13</version>
+      <version>5.0</version>
       <configuration>
         <chartDirectory>${project.basedir}</chartDirectory>
         <chartVersion>${project.version}</chartVersion>
@@ -88,7 +93,7 @@ and disables the auto-detection feature:
     <plugin>
       <groupId>com.kiwigrid</groupId>
       <artifactId>helm-maven-plugin</artifactId>
-      <version>4.13</version>
+      <version>5.0</version>
       <configuration>
         <chartDirectory>${project.basedir}</chartDirectory>
         <chartVersion>${project.version}</chartVersion>
@@ -111,7 +116,7 @@ and disables the auto-detection feature:
     <plugin>
       <groupId>com.kiwigrid</groupId>
       <artifactId>helm-maven-plugin</artifactId>
-      <version>4.13</version>
+      <version>5.0</version>
       <configuration>
         <chartDirectory>${project.basedir}</chartDirectory>
         <chartVersion>${project.version}</chartVersion>
@@ -126,8 +131,7 @@ and disables the auto-detection feature:
             <url>https://my.chart.museum:8080/api/charts</url>
             <type>CHARTMUSEUM</type>
         </uploadRepoSnapshot>
-        <helmDownloadUrl>https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz</helmDownloadUrl>
-        <helmHomeDirectory>${project.basedir}/target/helm/home</helmHomeDirectory>
+        <helmDownloadUrl>https://get.helm.sh/helm-v3.0.0-linux-amd64.tar.gz</helmDownloadUrl>
       </configuration>
     </plugin>
   ...
@@ -143,7 +147,7 @@ and disables the auto-detection feature:
     <plugin>
       <groupId>com.kiwigrid</groupId>
       <artifactId>helm-maven-plugin</artifactId>
-      <version>4.13</version>
+      <version>5.0</version>
       <configuration>
         <chartDirectory>${project.basedir}</chartDirectory>
         <chartVersion>${project.version}</chartVersion>
@@ -161,10 +165,13 @@ and disables the auto-detection feature:
             <url>https://my.chart.museum/api/charts</url>
             <type>CHARTMUSEUM</type>
         </uploadRepoSnapshot>
-        <helmDownloadUrl>https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz</helmDownloadUrl>
+        <helmDownloadUrl>https://get.helm.sh/helm-v3.0.0-linux-amd64.tar.gz</helmDownloadUrl>
         <helmHomeDirectory>${project.basedir}/target/helm/home</helmHomeDirectory>
-        <!-- Skip a single goal -->
-        <skipRefresh>false</skipRefresh>
+        <registryConfig>~/.config/helm/registry.json</registryConfig>
+        <repositoryCache>~/.cache/helm/repository</repositoryCache>
+        <repositoryConfig>~/.config/helm/repositories.yaml</repositoryConfig>
+        <!-- Lint with strict mode -->
+        <lintStrict>true</lintStrict>
         <!-- Exclude a directory to avoid processing -->
         <excludes>
           <exclude>${project.basedir}/excluded</exclude>
@@ -217,12 +224,14 @@ Parameter | Type | User Property | Required | Description
 `<autoDetectLocalHelmBinary>` | boolean | helm.autoDetectLocalHelmBinary | true | Controls whether the local binary should be auto-detected from `PATH` environment variable. If set to `false` the binary in `<helmExecutableDirectory>` is used. This property has no effect unless `<useLocalHelmBinary>` is set to `true`.
 `<helmExecutableDirectory>` | string | helm.executableDirectory | false | directory of your helm installation (default: `${project.build.directory}/helm`)
 `<outputDirectory>` | string | helm.outputDirectory | false | chart output directory (default: `${project.build.directory}/helm/repo`)
-`<helmHomeDirectory>` | string | helm.homeDirectory | false | path to helm home directory; useful for concurrent Jenkins builds! (default: `~/.helm`)
+`<registryConfig>` | string | helm.registryConfig | false | path to the registry config file
+`<repositoryCache>` | string | helm.repositoryCache | false | path to the file containing cached repository indexes
+`<repositoryConfig>` | string | helm.repositoryConfig | false | path to the file containing repository names and URLs
 `<helmExtraRepos>` | list of [HelmRepository](./src/main/java/com/kiwigrid/helm/maven/plugin/HelmRepository.java) | helm.extraRepos | false | adds extra repositories while init
 `<uploadRepoStable>`| [HelmRepository](./src/main/java/com/kiwigrid/helm/maven/plugin/HelmRepository.java) | helm.uploadRepo.stable | true | Upload repository for stable charts
 `<uploadRepoSnapshot>`| [HelmRepository](./src/main/java/com/kiwigrid/helm/maven/plugin/HelmRepository.java) | helm.uploadRepo.snapshot | false | Upload repository for snapshot charts (determined by version postfix 'SNAPSHOT')
+`lintStrict` | boolean | false | run lint command with strict option (fail on lint warnings)
 `<skip>` | boolean | helm.skip | false | skip plugin execution
-`<skipRefresh>` | boolean | helm.init.skipRefresh | false | do not refresh (download) the local repository cache while init
 `<skipInit>` | boolean | helm.init.skip | false | skip init goal
 `<skipLint>` | boolean | helm.lint.skip | false | skip lint goal
 `<skipDryRun>` | boolean | helm.dry-run.skip | false | skip dry-run goal

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.kiwigrid</groupId>
 	<artifactId>helm-maven-plugin</artifactId>
-	<version>4.14-SNAPSHOT</version>
+	<version>5.0-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>
@@ -92,7 +92,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
-			<version>1.18</version>
+			<version>1.19</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
@@ -76,8 +76,14 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 	@Parameter(property = "helm.downloadUrl")
 	private String helmDownloadUrl;
 
-	@Parameter(property = "helm.homeDirectory")
-	private String helmHomeDirectory;
+	@Parameter(property = "helm.registryConfig")
+	private String registryConfig;
+
+	@Parameter(property = "helm.repositoryCache")
+	private String repositoryCache;
+
+	@Parameter(property = "helm.repositoryConfig")
+	private String repositoryConfig;
 
 	@Parameter(property = "helm.extraRepos")
 	private HelmRepository[] helmExtraRepos;
@@ -347,12 +353,28 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 		this.chartDirectory = chartDirectory;
 	}
 
-	public String getHelmHomeDirectory() {
-		return helmHomeDirectory;
+	public String getRegistryConfig() {
+		return registryConfig;
 	}
 
-	public void setHelmHomeDirectory(String helmHomeDirectory) {
-		this.helmHomeDirectory = helmHomeDirectory;
+	public void setRegistryConfig(String registryConfig) {
+		this.registryConfig = registryConfig;
+	}
+
+	public String getRepositoryCache() {
+		return repositoryCache;
+	}
+
+	public void setRepositoryCache(String repositoryCache) {
+		this.repositoryCache = repositoryCache;
+	}
+
+	public String getRepositoryConfig() {
+		return repositoryConfig;
+	}
+
+	public void setRepositoryConfig(String repositoryConfig) {
+		this.repositoryConfig = repositoryConfig;
 	}
 
 	public String getChartVersion() {

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/DependencyBuildMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/DependencyBuildMojo.java
@@ -32,7 +32,9 @@ public class DependencyBuildMojo extends AbstractHelmMojo {
 			callCli(getHelmExecuteablePath()
 					+ " dependency build "
 					+ inputDirectory
-					+ (StringUtils.isNotEmpty(getHelmHomeDirectory()) ? " --home=" + getHelmHomeDirectory() : ""),
+					+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
+					+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache() : "")
+					+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig() : ""),
 					"Failed to resolve dependencies", true);
 		}
 	}

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/DryRunMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/DryRunMojo.java
@@ -33,7 +33,9 @@ public class DryRunMojo extends AbstractHelmMojo {
 					+ " " + action
 					+ " " + inputDirectory
 					+ " --dry-run"
-					+ (StringUtils.isNotEmpty(getHelmHomeDirectory()) ? " --home=" + getHelmHomeDirectory() : ""),
+					+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
+					+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache() : "")
+					+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig() : ""),
 					"There are test failures", true);
 		}
 	}

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/LintMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/LintMojo.java
@@ -20,6 +20,9 @@ public class LintMojo extends AbstractHelmMojo {
 	@Parameter(property = "helm.lint.skip", defaultValue = "false")
 	private boolean skipLint;
 
+	@Parameter(property = "helm.lint.strict", defaultValue = "false")
+	private boolean lintStrict;
+
 	public void execute()
 			throws MojoExecutionException
 	{
@@ -33,7 +36,10 @@ public class LintMojo extends AbstractHelmMojo {
 			callCli(getHelmExecuteablePath()
 					+ " lint "
 					+ inputDirectory
-					+ (StringUtils.isNotEmpty(getHelmHomeDirectory()) ? " --home=" + getHelmHomeDirectory() : ""),
+					+ (lintStrict ? " --strict" : "")
+					+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
+					+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache() : "")
+					+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig() : ""),
 					"There are test failures", true);
 		}
 	}

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/PackageMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/PackageMojo.java
@@ -37,7 +37,9 @@ public class PackageMojo extends AbstractHelmMojo {
 					+ inputDirectory
 					+ " -d "
 					+ getOutputDirectory()
-					+ (StringUtils.isNotEmpty(getHelmHomeDirectory()) ? " --home=" + getHelmHomeDirectory() : "");
+					+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
+					+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache() : "")
+					+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig() : "");
 
 			if (getChartVersion() != null) {
 				getLog().info(String.format("Setting chart version to %s", getChartVersion()));


### PR DESCRIPTION
This contains all changes to enable Helm3 support.
It contains breaking changes to Helm v2, but this will no longer be supported (maybe bugfixes only in urgent cases).

Fixes #64 