### PR TITLE
Add option to disable adding of default repo (stable) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add following dependency to your pom.xml:
 <dependency>
   <groupId>com.kiwigrid</groupId>
   <artifactId>helm-maven-plugin</artifactId>
-  <version>5.0</version>
+  <version>5.1</version>
 </dependency>
 ```
 
@@ -48,7 +48,7 @@ Add following dependency to your pom.xml:
     <plugin>
       <groupId>com.kiwigrid</groupId>
       <artifactId>helm-maven-plugin</artifactId>
-      <version>5.0</version>
+      <version>5.1</version>
       <configuration>
         <chartDirectory>${project.basedir}</chartDirectory>
         <chartVersion>${project.version}</chartVersion>
@@ -72,7 +72,7 @@ When `useLocalHelmBinary` is enabled, the plugin by default will search for the 
     <plugin>
       <groupId>com.kiwigrid</groupId>
       <artifactId>helm-maven-plugin</artifactId>
-      <version>5.0</version>
+      <version>5.1</version>
       <configuration>
         <chartDirectory>${project.basedir}</chartDirectory>
         <chartVersion>${project.version}</chartVersion>
@@ -95,7 +95,7 @@ and disables the auto-detection feature:
     <plugin>
       <groupId>com.kiwigrid</groupId>
       <artifactId>helm-maven-plugin</artifactId>
-      <version>5.0</version>
+      <version>5.1</version>
       <configuration>
         <chartDirectory>${project.basedir}</chartDirectory>
         <chartVersion>${project.version}</chartVersion>
@@ -118,7 +118,7 @@ and disables the auto-detection feature:
     <plugin>
       <groupId>com.kiwigrid</groupId>
       <artifactId>helm-maven-plugin</artifactId>
-      <version>5.0</version>
+      <version>5.1</version>
       <configuration>
         <chartDirectory>${project.basedir}</chartDirectory>
         <chartVersion>${project.version}</chartVersion>
@@ -149,7 +149,7 @@ and disables the auto-detection feature:
     <plugin>
       <groupId>com.kiwigrid</groupId>
       <artifactId>helm-maven-plugin</artifactId>
-      <version>5.0</version>
+      <version>5.1</version>
       <configuration>
         <chartDirectory>${project.basedir}</chartDirectory>
         <chartVersion>${project.version}</chartVersion>
@@ -174,6 +174,8 @@ and disables the auto-detection feature:
         <repositoryConfig>~/.config/helm/repositories.yaml</repositoryConfig>
         <!-- Lint with strict mode -->
         <lintStrict>true</lintStrict>
+        <!-- Disable adding of default repo stable https://kubernetes-charts.storage.googleapis.com -->
+        <addDefaultRepo>false</addDefaultRepo>
         <!-- Exclude a directory to avoid processing -->
         <excludes>
           <exclude>${project.basedir}/excluded</exclude>
@@ -232,7 +234,8 @@ Parameter | Type | User Property | Required | Description
 `<helmExtraRepos>` | list of [HelmRepository](./src/main/java/com/kiwigrid/helm/maven/plugin/HelmRepository.java) | helm.extraRepos | false | adds extra repositories while init
 `<uploadRepoStable>`| [HelmRepository](./src/main/java/com/kiwigrid/helm/maven/plugin/HelmRepository.java) | helm.uploadRepo.stable | true | Upload repository for stable charts
 `<uploadRepoSnapshot>`| [HelmRepository](./src/main/java/com/kiwigrid/helm/maven/plugin/HelmRepository.java) | helm.uploadRepo.snapshot | false | Upload repository for snapshot charts (determined by version postfix 'SNAPSHOT')
-`lintStrict` | boolean | helm.lint.strict | false | run lint command with strict option (fail on lint warnings)
+`<lintStrict>` | boolean | helm.lint.strict | false | run lint command with strict option (fail on lint warnings)
+`<addDefaultRepo>` | boolean | helm.init.add-default-repo | true | If true, stable repo (https://kubernetes-charts.storage.googleapis.com) will be added
 `<skip>` | boolean | helm.skip | false | skip plugin execution
 `<skipInit>` | boolean | helm.init.skip | false | skip init goal
 `<skipLint>` | boolean | helm.lint.skip | false | skip lint goal

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
@@ -48,6 +48,9 @@ public class InitMojo extends AbstractHelmMojo {
 	@Parameter(property = "helm.init.skip", defaultValue = "false")
 	private boolean skipInit;
 
+	@Parameter(property = "helm.init.add-default-repo", defaultValue = "true")
+	private boolean addDefaultRepo;
+
 	public void execute() throws MojoExecutionException {
 
 		if (skip || skipInit) {
@@ -73,15 +76,21 @@ public class InitMojo extends AbstractHelmMojo {
 			downloadAndUnpackHelm();
 		}
 
-		getLog().info("Adding default repo [stable]");
-		callCli(getHelmExecuteablePath()
-						+ " repo add stable https://kubernetes-charts.storage.googleapis.com"
-						+ " "
-						+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config " + getRegistryConfig() : "")
-						+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache " + getRepositoryCache() : "")
-						+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config " + getRepositoryConfig() : ""),
-				"Unable add repo",
-				false);
+		if (addDefaultRepo) {
+			getLog().info("Adding default repo [stable]");
+			callCli(getHelmExecuteablePath()
+							+ " repo add stable https://kubernetes-charts.storage.googleapis.com"
+							+ " "
+							+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config " + getRegistryConfig() : "")
+							+ (StringUtils.isNotEmpty(getRepositoryCache()) ?
+							" --repository-cache " + getRepositoryCache() :
+							"")
+							+ (StringUtils.isNotEmpty(getRepositoryConfig()) ?
+							" --repository-config " + getRepositoryConfig() :
+							""),
+					"Unable add repo",
+					false);
+		}
 
 		if (getHelmExtraRepos() != null) {
 			for (HelmRepository repository : getHelmExtraRepos()) {
@@ -148,6 +157,14 @@ public class InitMojo extends AbstractHelmMojo {
 		if (!found) {
 			throw new MojoExecutionException("Unable to find helm executable in tar file.");
 		}
+	}
+
+	public boolean isAddDefaultRepo() {
+		return addDefaultRepo;
+	}
+
+	public void setAddDefaultRepo(boolean addDefaultRepo) {
+		this.addDefaultRepo = addDefaultRepo;
 	}
 
 	private void addExecPermission(final Path helm) throws IOException {

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
@@ -60,6 +60,7 @@ public class InitMojoTest {
 		ArgumentCaptor<String> helmCommandCaptor = ArgumentCaptor.forClass(String.class);
 		doNothing().when(mojo).callCli(helmCommandCaptor.capture(), anyString(), anyBoolean());
 		mojo.setHelmDownloadUrl(getOsSpecificDownloadURL());
+		mojo.setAddDefaultRepo(true);
 
 		// run init
 		mojo.execute();
@@ -83,6 +84,7 @@ public class InitMojoTest {
 		mojo.setRegistryConfig("/path/to/my/registry.json");
 		mojo.setRepositoryCache("/path/to/my/repository/cache");
 		mojo.setRepositoryConfig("/path/to/my/repositories.yaml");
+		mojo.setAddDefaultRepo(true);
 
 		// run init
 		mojo.execute();


### PR DESCRIPTION
This change addresses #68, by introducing an option to disable adding of stable repo.

Adding of stable repo remains enabled by default for convenience reasons.