### PR TITLE
Support value override in LintMojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ and disables the auto-detection feature:
             <url>https://kiwigrid.github.io</url>
           </helmRepo>
         </helmExtraRepos>
+        <!-- extra value settings for the lint command -->
+        <values>
+          <overrides>
+            <component1.install.path>/opt/component1</component1.install.path>
+          </overrides>
+          <yamlFile>${project.basedir}/src/test/resources/myOverrides.yaml</yamlFile>
+        </values>
       </configuration>
     </plugin>
   ...
@@ -266,6 +273,7 @@ Parameter | Type | User Property | Required | Description
 `<skipPackage>` | boolean | helm.package.skip | false | skip package goal
 `<skipUpload>` | boolean | helm.upload.skip | false | skip upload goal
 `<security>` | string | helm.security | false | path to your [settings-security.xml](https://maven.apache.org/guides/mini/guide-encryption.html) (default: `~/.m2/settings-security.xml`)
+`<values>` | [ValueOverride](./src/main/java/com/kiwigrid/helm/maven/plugin/ValueOverride.java) | helm.values | false | override some values for linting with helm.values.overrides (--set option), helm.values.stringOverrides (--set-string option), helm.values.fileOverrides (--set-file option) and last but not least helm.values.yamlFile (--values option)
 
 ## Packaging with the Helm Lifecycle
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.12</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmWithValueOverrideMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmWithValueOverrideMojo.java
@@ -1,0 +1,58 @@
+package com.kiwigrid.helm.maven.plugin;
+
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import com.kiwigrid.helm.maven.plugin.pojo.ValueOverride;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public abstract class AbstractHelmWithValueOverrideMojo extends AbstractHelmMojo {
+    @Parameter(property = "helm.values")
+    private ValueOverride values;
+
+    protected String getValuesOptions() {
+        StringBuilder setValuesOptions = new StringBuilder();
+        if (values != null) {
+            if (isNotEmpty(values.getOverrides())) {
+                setValuesOptions.append(" --set ");
+                appendOverrideMap(setValuesOptions, values.getOverrides());
+            }
+            if (isNotEmpty(values.getStringOverrides())) {
+                setValuesOptions.append(" --set-string ");
+                appendOverrideMap(setValuesOptions, values.getStringOverrides());
+            }
+            if (isNotEmpty(values.getFileOverrides())) {
+                setValuesOptions.append(" --set-file ");
+                appendOverrideMap(setValuesOptions, values.getFileOverrides());
+            }
+            if (StringUtils.isNotBlank(values.getYamlFile())) {
+                setValuesOptions.append(" --values ").append(values.getYamlFile());
+            }
+        }
+        return setValuesOptions.toString();
+    }
+
+    private void appendOverrideMap(StringBuilder setValues, Map<String, String> overrides) {
+        boolean first = true;
+        for (Map.Entry<String, String> valueEntry : overrides.entrySet()) {
+            if (first) {
+                first = false;
+            } else {
+                setValues.append(',');
+            }
+            setValues.append(valueEntry.getKey()).append('=').append(valueEntry.getValue());
+        }
+    }
+
+    private static <K, V> boolean isNotEmpty(Map<K, V> map) {
+        return map != null && !map.isEmpty();
+    }
+
+
+}

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/LintMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/LintMojo.java
@@ -1,7 +1,5 @@
 package com.kiwigrid.helm.maven.plugin;
 
-import java.util.Arrays;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -15,7 +13,7 @@ import org.codehaus.plexus.util.StringUtils;
  * @since 06.11.17
  */
 @Mojo(name = "lint", defaultPhase = LifecyclePhase.TEST)
-public class LintMojo extends AbstractHelmMojo {
+public class LintMojo extends AbstractHelmWithValueOverrideMojo {
 
 	@Parameter(property = "helm.lint.skip", defaultValue = "false")
 	private boolean skipLint;
@@ -39,7 +37,8 @@ public class LintMojo extends AbstractHelmMojo {
 					+ (lintStrict ? " --strict" : "")
 					+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
 					+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache() : "")
-					+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig() : ""),
+					+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig() : "")
+					+ getValuesOptions(),
 					"There are test failures", true);
 		}
 	}

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/pojo/HelmRepository.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/pojo/HelmRepository.java
@@ -2,12 +2,17 @@ package com.kiwigrid.helm.maven.plugin.pojo;
 
 import org.apache.maven.plugins.annotations.Parameter;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * POJO for extra repo configuration
  *
  * @author Fabian Schlegel
  * @since 22.2.18
  */
+@Getter
+@Setter
 public class HelmRepository {
 
 	/**
@@ -35,46 +40,6 @@ public class HelmRepository {
 
 	@Parameter(property = "helm.repo.type")
 	private RepoType type;
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public String getUrl() {
-		return url;
-	}
-
-	public void setUrl(String url) {
-		this.url = url;
-	}
-
-	public String getUsername() {
-		return username;
-	}
-
-	public void setUsername(String username) {
-		this.username = username;
-	}
-
-	public String getPassword() {
-		return password;
-	}
-
-	public void setPassword(String password) {
-		this.password = password;
-	}
-
-	public RepoType getType() {
-		return type;
-	}
-
-	public void setType(RepoType type) {
-		this.type = type;
-	}
 
 	@Override
 	public String toString() {

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/pojo/ValueOverride.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/pojo/ValueOverride.java
@@ -1,0 +1,57 @@
+package com.kiwigrid.helm.maven.plugin.pojo;
+
+import java.util.Map;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * POJO for extra value override configuration (typically passed with --set or -f options)
+ *
+ * @author Emile de Weerd
+ * @since October 12th 2020
+ */
+@Getter
+@Setter
+@ToString
+public class ValueOverride {
+    /**
+     * Values that will be passed with the option --set of helm command line.
+     */
+    @Parameter(property = "helm.values.overrides")
+    private Map<String, String> overrides;
+
+    /**
+     * Values that will be passed with the option --set-string to the helm command line.
+     *
+     * <p>
+     * This option forces the values to be transformed and manipulated as strings by Go template.
+     * </p>
+     */
+    @Parameter(property = "helm.values.stringOverrides")
+    private Map<String, String> stringOverrides;
+
+    /**
+     * Values that will be passed with the option --set-file to the helm command line.
+     *
+     * <p>
+     * Values here point to files that contain the content you want to inject. Very useful to use with en entire script
+     * you want to insert optionally somewhere for instance.
+     * </p>
+     */
+    @Parameter(property = "helm.values.fileOverrides")
+    private Map<String, String> fileOverrides;
+
+    /**
+     * Value YAML file that will be passed with option --values or -f of the helm command line.
+     *
+     * <p>
+     * It can be seen as creating a temporary extending chart with its dedicated values.yaml.
+     * </p>
+     */
+    @Parameter(property = "helm.values.yamlFile")
+    private String yamlFile;
+}

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/AbstractHelmWithValueOverrideMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/AbstractHelmWithValueOverrideMojoTest.java
@@ -1,0 +1,99 @@
+package com.kiwigrid.helm.maven.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.LinkedHashMap;
+
+import org.junit.jupiter.api.Test;
+
+import com.kiwigrid.helm.maven.plugin.pojo.ValueOverride;
+
+class AbstractHelmWithValueOverrideMojoTest {
+
+    private NoopHelmMojo testMojo = new NoopHelmMojo();
+
+    @Test
+    public void noValueOverrideNoValueOption() {
+        assertEquals("", testMojo.getValuesOptions(), "without any configuration no values options ");
+    }
+
+    @Test
+    public void normalValueOverride() {
+        ValueOverride override = new ValueOverride();
+        override.setOverrides(new LinkedHashMap<>());
+        override.getOverrides().put("key1", "value1");
+        testMojo.setValues(override);
+
+        assertEquals(" --set key1=value1", testMojo.getValuesOptions());
+    }
+
+    @Test
+    public void multipleNormalValueOverrides() {
+        ValueOverride override = new ValueOverride();
+        override.setOverrides(new LinkedHashMap<>());
+        override.getOverrides().put("key1", "value1");
+        override.getOverrides().put("key2", "value2");
+        testMojo.setValues(override);
+
+        assertEquals(" --set key1=value1,key2=value2", testMojo.getValuesOptions());
+    }
+
+    @Test
+    public void stringValueOverrides() {
+        ValueOverride override = new ValueOverride();
+        override.setStringOverrides(new LinkedHashMap<>());
+        override.getStringOverrides().put("key1", "value1");
+        override.getStringOverrides().put("key2", "value2");
+        testMojo.setValues(override);
+
+        assertEquals(" --set-string key1=value1,key2=value2", testMojo.getValuesOptions());
+    }
+
+    @Test
+    public void fileValueOverrides() {
+        ValueOverride override = new ValueOverride();
+        override.setFileOverrides(new LinkedHashMap<>());
+        override.getFileOverrides().put("key1", "path/to/file1.txt");
+        override.getFileOverrides().put("key2", "D:/absolute/path/to/file2.txt");
+        testMojo.setValues(override);
+
+        assertEquals(" --set-file key1=path/to/file1.txt,key2=D:/absolute/path/to/file2.txt", testMojo.getValuesOptions());
+    }
+
+    @Test
+    public void valueYamlOverride() {
+        ValueOverride override = new ValueOverride();
+        override.setYamlFile("path/to/values.yaml");
+        testMojo.setValues(override);
+
+        assertEquals(" --values path/to/values.yaml", testMojo.getValuesOptions());
+    }
+
+
+    @Test
+    public void allOverrideUsedTogether() {
+        ValueOverride override = new ValueOverride();
+        override.setOverrides(new LinkedHashMap<>());
+        override.getOverrides().put("key1", "value1");
+        override.getOverrides().put("key2", "value2");
+        override.setStringOverrides(new LinkedHashMap<>());
+        override.getStringOverrides().put("skey1", "svalue1");
+        override.getStringOverrides().put("skey2", "svalue2");
+        override.setFileOverrides(new LinkedHashMap<>());
+        override.getFileOverrides().put("fkey1", "path/to/file1.txt");
+        override.getFileOverrides().put("fkey2", "D:/absolute/path/to/file2.txt");
+        override.setYamlFile("path/to/values.yaml");
+        testMojo.setValues(override);
+
+        assertEquals(" --set key1=value1,key2=value2 --set-string skey1=svalue1,skey2=svalue2 --set-file " +
+                        "fkey1=path/to/file1.txt,fkey2=D:/absolute/path/to/file2.txt --values path/to/values.yaml",
+                testMojo.getValuesOptions());
+    }
+
+
+    private static class NoopHelmMojo extends AbstractHelmWithValueOverrideMojo {
+
+        @Override
+        public void execute() { /* Noop. */ }
+    }
+}

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
@@ -15,6 +15,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.Os;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -30,6 +32,7 @@ import static org.mockito.Mockito.doReturn;
 @MojoProperty(name = "helmDownloadUrl", value = "https://get.helm.sh/helm-v3.0.0-linux-amd64.tar.gz")
 @MojoProperty(name = "chartDirectory", value = "junit-helm")
 @MojoProperty(name = "chartVersion", value = "0.0.1")
+@EnabledOnOs(OS.LINUX)
 public class InitMojoTest {
 
 	@DisplayName("Init helm with different download urls.")

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/LintMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/LintMojoTest.java
@@ -1,0 +1,41 @@
+package com.kiwigrid.helm.maven.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+
+import java.nio.file.Paths;
+
+import org.codehaus.plexus.util.Os;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import com.kiwigrid.helm.maven.plugin.junit.MojoExtension;
+import com.kiwigrid.helm.maven.plugin.junit.MojoProperty;
+import com.kiwigrid.helm.maven.plugin.junit.SystemPropertyExtension;
+import com.kiwigrid.helm.maven.plugin.pojo.ValueOverride;
+
+@ExtendWith({SystemPropertyExtension.class, MojoExtension.class})
+@MojoProperty(name = "helmDownloadUrl", value = "https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz")
+@MojoProperty(name = "chartDirectory", value = "junit-chart")
+@MojoProperty(name = "chartVersion", value = "0.0.1")
+public class LintMojoTest {
+    @Test
+    public void valuesFile(LintMojo mojo) throws Exception {
+        ValueOverride override = new ValueOverride();
+        override.setYamlFile("overrideValues.yaml");
+        mojo.setValues(override);
+        mojo.setChartDirectory(Paths.get(getClass().getResource("Chart.yaml").toURI()).getParent().toString());
+
+        ArgumentCaptor<String> helmCommandCaptor = ArgumentCaptor.forClass(String.class);
+        doNothing().when(mojo).callCli(helmCommandCaptor.capture(), anyString(), anyBoolean());
+        doReturn(Paths.get("helm" + (Os.OS_FAMILY == Os.FAMILY_WINDOWS ? ".exe" : ""))).when(mojo).getHelmExecuteablePath();
+
+        mojo.execute();
+
+        assertTrue(helmCommandCaptor.getValue().contains("--values overrideValues.yaml"));
+    }
+}


### PR DESCRIPTION
Resolves #74

Helm lint command (as well as upgrade, install and template, but they are not supported by the plugin) has 4 options that allow to override per call some values. It is all explained here: https://helm.sh/docs/helm/helm_install/

It is quite useful, typical use case: you develop a chart that is supposed to be reused by others, with a value field that is mandatory. By default it is "" and you insert it with {{ required "provide my prop or you'll die" .Values.myProp }}. Final users will have to provide it otherwise their install's gonna fail.

But you still want to lint your chart before releasing it. The linting with the empty string default value will systematically fail. Unless you provide an override just for the linting. Hence the usage of --set myProp=dummyValue.

 Example of configuration that this PR allows:

```xml
<configuration>
  <values>
    <overrides>
      <component1.myProp1>value1</component1.myProp1>
    </overrides>
    <stringOverrides>
      <component1.myProp2>value2</component1.myProp2>
    </stringOverrides>
    <fileOverrides>
      <component1.scriptContents>path/to/exampleScript.sh</component1.scriptContents>
    </fileOverrides>
    <yamlFile>path/to/myValues.yaml</yamlFile>
  </values>
</configuration>
```

Which will generate the following options on LintMojo:

```
    --set component1.myProp1=value1 \
    --set-string component1.myProp2=value2 \
    --set-file component1.scriptContents=path/to/exampleScript.sh \
    --values path/to/myValues.yaml
```

Resume of changes:

* Create a new AbstractMojo with the value option and the generation of the different corresponding options
* Make LintMojo depend on it
* Unit test and integration tests that goes with it
* Add lombok to dependencies to limit boilerplate code
* Add EnableOn(Os.LINUX) on some tests that do not run on Windows typically