### PR TITLE
Support for signing charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ and disables the auto-detection feature:
         <registryConfig>~/.config/helm/registry.json</registryConfig>
         <repositoryCache>~/.cache/helm/repository</repositoryCache>
         <repositoryConfig>~/.config/helm/repositories.yaml</repositoryConfig>
+        <!-- Add a gpg signature to the chart -->
+        <keyring>~/.gpg/secring.gpg</keyring>
+        <key>MySigningKey</key>
+        <passphrase>SecretPassPhrase</passphrase>
         <!-- Lint with strict mode -->
         <lintStrict>true</lintStrict>
         <!-- Disable adding of default repo stable https://kubernetes-charts.storage.googleapis.com -->
@@ -273,6 +277,9 @@ Parameter | Type | User Property | Required | Description
 `<skipPackage>` | boolean | helm.package.skip | false | skip package goal
 `<skipUpload>` | boolean | helm.upload.skip | false | skip upload goal
 `<security>` | string | helm.security | false | path to your [settings-security.xml](https://maven.apache.org/guides/mini/guide-encryption.html) (default: `~/.m2/settings-security.xml`)
+`<keyring>` | string | helm.package.keyring | false | path to gpg secret keyring for signing
+`<key>` | string  | helm.package.key | false | name of gpg key in keyring
+`<passphrase>` | string | helm.package.passphrase | false | passphrase for gpg key (requires helm 3.4 or newer)
 `<values>` | [ValueOverride](./src/main/java/com/kiwigrid/helm/maven/plugin/ValueOverride.java) | helm.values | false | override some values for linting with helm.values.overrides (--set option), helm.values.stringOverrides (--set-string option), helm.values.fileOverrides (--set-file option) and last but not least helm.values.yamlFile (--values option)
 
 ## Packaging with the Helm Lifecycle

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
@@ -4,7 +4,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.PasswordAuthentication;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Path;
@@ -140,6 +142,7 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 		return System.getenv("PATH").split(Pattern.quote(File.pathSeparator));
 	}
 
+
 	/**
 	 * Calls cli with specified command
 	 *
@@ -148,8 +151,20 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 	 * @param verbose logs STDOUT to Maven info log
 	 * @throws MojoExecutionException on error
 	 */
-	void callCli(String command, String errorMessage, final boolean verbose) throws MojoExecutionException {
+	void callCli(String command, String errorMessage, boolean verbose) throws MojoExecutionException {
+		callCli(command, errorMessage, verbose, null);
+	}
 
+	/**
+	 * Calls cli with specified command
+	 *
+	 * @param command the command to be executed
+	 * @param errorMessage a readable error message that will be shown in case of exceptions
+	 * @param verbose logs STDOUT to Maven info log
+	 * @param stdin STDIN which is passed to the helm process
+	 * @throws MojoExecutionException on error
+	 */
+	void callCli(String command, String errorMessage, final boolean verbose, String stdin) throws MojoExecutionException {
 		int exitValue;
 
 		getLog().debug(command);
@@ -157,6 +172,14 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 		try {
 			final Process p = Runtime.getRuntime().exec(command);
 			new Thread(() -> {
+				if (StringUtils.isNotEmpty(stdin)) {
+					try (OutputStream outputStream = p.getOutputStream()) {
+						outputStream.write( stdin.getBytes(StandardCharsets.UTF_8) );
+					} catch (IOException ex) {
+						getLog().error("failed to write to stdin of helm", ex);
+					}
+				}
+
 				BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()));
 				BufferedReader error = new BufferedReader(new InputStreamReader(p.getErrorStream()));
 				String inputLine;
@@ -229,14 +252,19 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 		};
 	}
 
-	List<String> getChartTgzs(String path) throws MojoExecutionException {
+	List<String> getChartFiles(String path) throws MojoExecutionException {
 		try (Stream<Path> files = Files.walk(Paths.get(path))) {
-			return files.filter(p -> p.getFileName().toString().endsWith("tgz"))
+			return files.filter(this::isChartFile)
 					.map(Path::toString)
 					.collect(Collectors.toList());
 		} catch (IOException e) {
 			throw new MojoExecutionException("Unable to scan repo directory at " + path, e);
 		}
+	}
+
+	private boolean isChartFile(Path p) {
+		String filename = p.getFileName().toString();
+		return filename.endsWith(".tgz") || filename.endsWith("tgz.prov");
 	}
 
 	/**

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/UploadMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/UploadMojo.java
@@ -41,7 +41,7 @@ public class UploadMojo extends AbstractHelmMojo {
 			return;
 		}
 		getLog().info("Uploading to " + getHelmUploadUrl() + "\n");
-		for (String chartPackageFile : getChartTgzs(getOutputDirectory())) {
+		for (String chartPackageFile : getChartFiles(getOutputDirectory())) {
 			getLog().info("Uploading " + chartPackageFile + "...");
 			try {
 				uploadSingle(chartPackageFile);

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/UploadMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/UploadMojoTest.java
@@ -44,11 +44,11 @@ public class UploadMojoTest {
 		tgzs.add(resource.getFile());
 
 		doReturn(helmRepo).when(mojo).getHelmUploadRepo();
-		doReturn(tgzs).when(mojo).getChartTgzs(anyString());
+		doReturn(tgzs).when(mojo).getChartFiles(anyString());
 
 		assertThrows(IllegalArgumentException.class, mojo::execute, "Missing credentials must fail.");
 	}
-	
+
 	@Test
 	public void uploadToArtifactoryWithRepositoryCredentials(UploadMojo mojo) throws IOException, MojoExecutionException {
 		final HelmRepository helmRepo = new HelmRepository();
@@ -57,19 +57,19 @@ public class UploadMojoTest {
 		helmRepo.setUrl("https://somwhere.com/repo");
 		helmRepo.setUsername("foo");
 		helmRepo.setPassword("bar");
-		mojo.setUploadRepoStable(helmRepo);		
-		
+		mojo.setUploadRepoStable(helmRepo);
+
 		final URL resource = this.getClass().getResource("app-0.1.0.tgz");
 		final File fileToUpload = new File(resource.getFile());
 		final List<String> tgzs = new ArrayList<>();
 		tgzs.add(resource.getFile());
-		
+
 		doReturn(helmRepo).when(mojo).getHelmUploadRepo();
-		doReturn(tgzs).when(mojo).getChartTgzs(anyString());
-		
+		doReturn(tgzs).when(mojo).getChartFiles(anyString());
+
 		assertNotNull(mojo.getConnectionForUploadToArtifactory(fileToUpload));
 	}
-	
+
 	@Test
 	public void uploadToArtifactoryWithPlainCredentialsFromSettings(UploadMojo mojo) throws IOException, MojoExecutionException {
 		final Server server = new Server();
@@ -79,24 +79,24 @@ public class UploadMojoTest {
 		final List<Server> servers = new ArrayList<>();
 		servers.add(server);
 		mojo.getSettings().setServers(servers);
-		
+
 		final HelmRepository helmRepo = new HelmRepository();
 		helmRepo.setType(RepoType.ARTIFACTORY);
 		helmRepo.setName("my-artifactory");
 		helmRepo.setUrl("https://somwhere.com/repo");
-		mojo.setUploadRepoStable(helmRepo);		
-		
+		mojo.setUploadRepoStable(helmRepo);
+
 		final URL resource = this.getClass().getResource("app-0.1.0.tgz");
 		final File fileToUpload = new File(resource.getFile());
 		final List<String> tgzs = new ArrayList<>();
 		tgzs.add(resource.getFile());
 
 		doReturn(helmRepo).when(mojo).getHelmUploadRepo();
-		doReturn(tgzs).when(mojo).getChartTgzs(anyString());
+		doReturn(tgzs).when(mojo).getChartFiles(anyString());
 
 		assertNotNull(mojo.getConnectionForUploadToArtifactory(fileToUpload));
 	}
-	
+
 	@Test
 	public void uploadToArtifactoryWithEncryptedCredentialsFromSettings(UploadMojo mojo) throws IOException, MojoExecutionException {
 		final Server server = new Server();
@@ -106,13 +106,13 @@ public class UploadMojoTest {
 		final List<Server> servers = new ArrayList<>();
 		servers.add(server);
 		mojo.getSettings().setServers(servers);
-		
+
 		final HelmRepository helmRepo = new HelmRepository();
 		helmRepo.setType(RepoType.ARTIFACTORY);
 		helmRepo.setName("my-artifactory");
 		helmRepo.setUrl("https://somwhere.com/repo");
-		mojo.setUploadRepoStable(helmRepo);		
-		
+		mojo.setUploadRepoStable(helmRepo);
+
 		final URL resource = this.getClass().getResource("app-0.1.0.tgz");
 		final File fileToUpload = new File(resource.getFile());
 		final List<String> tgzs = new ArrayList<>();
@@ -120,8 +120,8 @@ public class UploadMojoTest {
 
 		doReturn(this.getClass().getResource("settings-security.xml").getFile()).when(mojo).getHelmSecurity();
 		doReturn(helmRepo).when(mojo).getHelmUploadRepo();
-		doReturn(tgzs).when(mojo).getChartTgzs(anyString());
-		
+		doReturn(tgzs).when(mojo).getChartFiles(anyString());
+
 		assertNotNull(mojo.getConnectionForUploadToArtifactory(fileToUpload));
 
 		final PasswordAuthentication pwd = Authenticator.requestPasswordAuthentication(InetAddress.getLocalHost(), 443, "https", "", "basicauth");
@@ -191,7 +191,7 @@ public class UploadMojoTest {
 		uploadMojo.setUploadRepoStable(helmRepo);
 
 		doReturn(helmRepo).when(uploadMojo).getHelmUploadRepo();
-		doReturn(tgzs).when(uploadMojo).getChartTgzs(anyString());
+		doReturn(tgzs).when(uploadMojo).getChartFiles(anyString());
 
 		HttpURLConnection urlConnectionMock = Mockito.mock(HttpURLConnection.class);
 		doReturn(new NullOutputStream()).when(urlConnectionMock).getOutputStream();
@@ -218,7 +218,7 @@ public class UploadMojoTest {
 		tgzs.add(resource.getFile());
 
 		doReturn(helmRepo).when(uploadMojo).getHelmUploadRepo();
-		doReturn(tgzs).when(uploadMojo).getChartTgzs(anyString());
+		doReturn(tgzs).when(uploadMojo).getChartFiles(anyString());
 
 		assertThrows(IllegalArgumentException.class, uploadMojo::execute, "Missing repo type must fail.");
 	}


### PR DESCRIPTION
This pr will add options to sign charts. The passphrase option requires at least helm 3.4.

Fixes #92 

Additional Information:

* https://helm.sh/docs/topics/provenance/
* [PR #8394](https://github.com/helm/helm/pull/8394) which adds support reading signing passphrase