### PR TITLE
Add upload repos for the dependency build via the new property: helm.init.add-upload-repos (fix for issue #109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Parameter | Type | User Property | Required | Description
 `<uploadRepoSnapshot>`| [HelmRepository](./src/main/java/com/kiwigrid/helm/maven/plugin/HelmRepository.java) | helm.uploadRepo.snapshot | false | Upload repository for snapshot charts (determined by version postfix 'SNAPSHOT')
 `<lintStrict>` | boolean | helm.lint.strict | false | run lint command with strict option (fail on lint warnings)
 `<addDefaultRepo>` | boolean | helm.init.add-default-repo | true | If true, stable repo (https://charts.helm.sh/stable) will be added
+`<addUploadRepos>` | boolean | helm.init.add-upload-repos | false | If true, upload repos (uploadRepoStable, uploadRepoSnapshot) will be added, if configured
 `<skip>` | boolean | helm.skip | false | skip plugin execution
 `<skipInit>` | boolean | helm.init.skip | false | skip init goal
 `<skipLint>` | boolean | helm.lint.skip | false | skip lint goal

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
@@ -95,7 +95,8 @@ public class InitMojo extends AbstractHelmMojo {
 				addRepository(getUploadRepoStable());
 			}
 
-			if (getUploadRepoSnapshot() != null) {
+			//add the upload snapshot repo only if it's name differs to the upload repo stable name
+			if (getUploadRepoSnapshot() != null && (getUploadRepoStable()==null || !getUploadRepoStable().getName().equals(getUploadRepoSnapshot().getName()))) {
 				addRepository(getUploadRepoSnapshot());
 			}
 		}

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
@@ -53,6 +53,11 @@ public class InitMojo extends AbstractHelmMojo {
 	@Parameter(property = "helm.init.add-default-repo", defaultValue = "true")
 	private boolean addDefaultRepo;
 
+	@Parameter(property = "helm.init.add-upload-repos", defaultValue = "false")
+	private boolean addUploadRepos;
+
+	public static final String STABLE_HELM_REPO = "https://charts.helm.sh/stable";
+
 	public void execute() throws MojoExecutionException {
 
 		if (skip || skipInit) {
@@ -79,38 +84,58 @@ public class InitMojo extends AbstractHelmMojo {
 		}
 
 		if (addDefaultRepo) {
-			getLog().info("Adding default repo [stable]");
-			callCli(getHelmExecuteablePath()
-							+ " repo add stable https://charts.helm.sh/stable"
-							+ " "
-							+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config " + getRegistryConfig() : "")
-							+ (StringUtils.isNotEmpty(getRepositoryCache()) ?
-							" --repository-cache " + getRepositoryCache() :
-							"")
-							+ (StringUtils.isNotEmpty(getRepositoryConfig()) ?
-							" --repository-config " + getRepositoryConfig() :
-							""),
-					"Unable add repo",
-					false);
+			HelmRepository stableHelmRepo = new HelmRepository();
+			stableHelmRepo.setName("stable");
+			stableHelmRepo.setUrl(STABLE_HELM_REPO);
+			addRepository(stableHelmRepo, false);
+		}
+
+		if (addUploadRepos) {
+			if (getUploadRepoStable() != null) {
+				addRepository(getUploadRepoStable());
+			}
+
+			if (getUploadRepoSnapshot() != null) {
+				addRepository(getUploadRepoSnapshot());
+			}
 		}
 
 		if (getHelmExtraRepos() != null) {
 			for (HelmRepository repository : getHelmExtraRepos()) {
-				getLog().info("Adding repo [" + repository +"]");
-				PasswordAuthentication auth = getAuthentication(repository);
-				callCli(getHelmExecuteablePath()
-								+ " repo add "
-								+ repository.getName()
-								+ " "
-								+ repository.getUrl()
-								+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
-								+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache() : "")
-								+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig() : "")
-								+ (auth != null ? " --username=" + auth.getUserName() + " --password=" + String.valueOf(auth.getPassword()) : ""),
-						"Unable add repo",
-						false);
+				addRepository(repository);
 			}
 		}
+	}
+
+	/**
+	 * Adds the helm repository to the helm, with repo authentication
+	 *
+	 * @param repository - helm repository to be added
+	 */
+	private void addRepository(final HelmRepository repository) throws MojoExecutionException {
+		addRepository(repository, true);
+	}
+
+	/**
+	 * Adds the helm repository to the helm
+	 *
+	 * @param repository - helm repository to be added
+	 * @param authenticationRequired - defines whether the authentication is required
+	 */
+	private void addRepository(final HelmRepository repository, boolean authenticationRequired) throws MojoExecutionException {
+		getLog().info("Adding repo [" + repository + "]");
+		PasswordAuthentication auth = authenticationRequired ? getAuthentication(repository) : null;
+		callCli(getHelmExecuteablePath()
+						+ " repo add "
+						+ repository.getName()
+						+ " "
+						+ repository.getUrl()
+						+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
+						+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache() : "")
+						+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig() : "")
+						+ (auth != null ? " --username=" + auth.getUserName() + " --password=" + String.valueOf(auth.getPassword()) : ""),
+						"Unable add repo",
+						false);
 	}
 
 	protected void downloadAndUnpackHelm() throws MojoExecutionException {
@@ -175,6 +200,14 @@ public class InitMojo extends AbstractHelmMojo {
 
 	public void setAddDefaultRepo(boolean addDefaultRepo) {
 		this.addDefaultRepo = addDefaultRepo;
+	}
+
+	public boolean isAddUploadRepos() {
+		return addUploadRepos;
+	}
+
+	public void setAddUploadRepos(boolean addUploadRepos) {
+		this.addUploadRepos = addUploadRepos;
 	}
 
 	private void addExecPermission(final Path helm) throws IOException {

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
@@ -6,11 +6,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.kiwigrid.helm.maven.plugin.junit.MojoExtension;
 import com.kiwigrid.helm.maven.plugin.junit.MojoProperty;
 import com.kiwigrid.helm.maven.plugin.junit.SystemPropertyExtension;
+import com.kiwigrid.helm.maven.plugin.pojo.HelmRepository;
+import com.kiwigrid.helm.maven.plugin.pojo.RepoType;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.Os;
 import org.junit.jupiter.api.DisplayName;
@@ -32,7 +36,6 @@ import static org.mockito.Mockito.doReturn;
 @MojoProperty(name = "helmDownloadUrl", value = "https://get.helm.sh/helm-v3.0.0-linux-amd64.tar.gz")
 @MojoProperty(name = "chartDirectory", value = "junit-helm")
 @MojoProperty(name = "chartVersion", value = "0.0.1")
-@EnabledOnOs(OS.LINUX)
 public class InitMojoTest {
 
 	@DisplayName("Init helm with different download urls.")
@@ -85,6 +88,7 @@ public class InitMojoTest {
 		doNothing().when(mojo).callCli(helmCommandCaptor.capture(), anyString(), anyBoolean());
 		mojo.setHelmDownloadUrl(getOsSpecificDownloadURL());
 		mojo.setAddDefaultRepo(true);
+		mojo.setAddUploadRepos(false);
 
 		// run init
 		mojo.execute();
@@ -95,7 +99,177 @@ public class InitMojoTest {
 				.filter(cmd -> cmd.contains(Os.OS_FAMILY == Os.FAMILY_WINDOWS ? "helm.exe repo" : "helm repo"))
 				.findAny().orElseThrow(() -> new IllegalArgumentException("Only one helm repo command expected"));
 
-		assertTrue(helmDefaultCommand.contains("repo add stable https://charts.helm.sh/stable"), "Adding stable repo by default expected");
+		assertTrue(helmDefaultCommand.contains("repo add stable "+ InitMojo.STABLE_HELM_REPO), "Adding stable repo by default expected");
+	}
+
+	@Test
+	public void verifyAddingUploadSnapshotRepoNoDefaultRepo(InitMojo mojo) throws Exception {
+
+		// prepare execution
+		final HelmRepository helmRepo = new HelmRepository();
+		helmRepo.setType(RepoType.ARTIFACTORY);
+		helmRepo.setName("my-artifactory-snapshot");
+		helmRepo.setUrl("https://somwhere.com/repo");
+		mojo.setUploadRepoSnapshot(helmRepo);
+		ArgumentCaptor<String> helmCommandCaptor = ArgumentCaptor.forClass(String.class);
+		doNothing().when(mojo).callCli(helmCommandCaptor.capture(), anyString(), anyBoolean());
+		mojo.setHelmDownloadUrl(getOsSpecificDownloadURL());
+		mojo.setAddDefaultRepo(false);
+		mojo.setAddUploadRepos(true);
+
+		// run init
+		mojo.execute();
+
+		// check captured argument
+		String helmCommand = helmCommandCaptor.getAllValues()
+				.stream()
+				.filter(cmd -> cmd.contains(Os.OS_FAMILY == Os.FAMILY_WINDOWS ? "helm.exe repo" : "helm repo"))
+				.findAny().orElseThrow(() -> new IllegalArgumentException("Only one helm repo command expected"));
+
+		assertTrue(helmCommand.contains("repo add my-artifactory-snapshot https://somwhere.com/repo"), "Adding upload snapshot repo expected");
+	}
+
+	@Test
+	public void verifyAddingUploadStableRepoNoDefaultRepo(InitMojo mojo) throws Exception {
+
+		// prepare execution
+		final HelmRepository helmRepo = new HelmRepository();
+		helmRepo.setType(RepoType.ARTIFACTORY);
+		helmRepo.setName("my-artifactory-stable");
+		helmRepo.setUrl("https://somwhere.com/repo/stable");
+		mojo.setUploadRepoStable(helmRepo);
+		ArgumentCaptor<String> helmCommandCaptor = ArgumentCaptor.forClass(String.class);
+		doNothing().when(mojo).callCli(helmCommandCaptor.capture(), anyString(), anyBoolean());
+		mojo.setHelmDownloadUrl(getOsSpecificDownloadURL());
+		mojo.setAddDefaultRepo(false);
+		mojo.setAddUploadRepos(true);
+
+		// run init
+		mojo.execute();
+
+		// check captured argument
+		String helmCommand = helmCommandCaptor.getAllValues()
+				.stream()
+				.filter(cmd -> cmd.contains(Os.OS_FAMILY == Os.FAMILY_WINDOWS ? "helm.exe repo" : "helm repo"))
+				.findAny().orElseThrow(() -> new IllegalArgumentException("Only one helm repo command expected"));
+
+		assertTrue(helmCommand.contains("repo add my-artifactory-stable https://somwhere.com/repo/stable"), "Adding upload stable repo expected");
+	}
+
+	@Test
+	public void verifyAddingUploadReposButNoRepoDefined(InitMojo mojo) throws Exception {
+
+		// prepare execution
+		ArgumentCaptor<String> helmCommandCaptor = ArgumentCaptor.forClass(String.class);
+		doNothing().when(mojo).callCli(helmCommandCaptor.capture(), anyString(), anyBoolean());
+		mojo.setHelmDownloadUrl(getOsSpecificDownloadURL());
+		mojo.setAddDefaultRepo(false);
+		mojo.setAddUploadRepos(true);
+
+		// run init
+		mojo.execute();
+
+		// check captured argument
+		Optional<String> helmCommand = helmCommandCaptor.getAllValues()
+				.stream()
+				.filter(cmd -> cmd.contains(Os.OS_FAMILY == Os.FAMILY_WINDOWS ? "helm.exe repo" : "helm repo"))
+				.findFirst();
+
+		assertFalse(helmCommand.isPresent(), "Adding repos not expected");
+	}
+
+	@Test
+	public void verifyAddingUploadSnapshotStableRepoAndDefaultRepo(InitMojo mojo) throws Exception {
+
+		// prepare execution
+		final HelmRepository helmUploadStableRepo = new HelmRepository();
+		helmUploadStableRepo.setType(RepoType.ARTIFACTORY);
+		helmUploadStableRepo.setName("my-artifactory-stable");
+		helmUploadStableRepo.setUrl("https://somwhere.com/repo/stable");
+		mojo.setUploadRepoStable(helmUploadStableRepo);
+		final HelmRepository helmUploadSnapshotRepo = new HelmRepository();
+		helmUploadSnapshotRepo.setType(RepoType.ARTIFACTORY);
+		helmUploadSnapshotRepo.setName("my-artifactory-snapshot");
+		helmUploadSnapshotRepo.setUrl("https://somwhere.com/repo/snapshot");
+		mojo.setUploadRepoSnapshot(helmUploadSnapshotRepo);
+		ArgumentCaptor<String> helmCommandCaptor = ArgumentCaptor.forClass(String.class);
+		doNothing().when(mojo).callCli(helmCommandCaptor.capture(), anyString(), anyBoolean());
+		mojo.setHelmDownloadUrl(getOsSpecificDownloadURL());
+		mojo.setAddDefaultRepo(true);
+		mojo.setAddUploadRepos(true);
+
+		// run init7
+		mojo.execute();
+
+		// check captured commands
+		Set<String> helmCommands = helmCommandCaptor.getAllValues()
+				.stream()
+				.filter(cmd -> cmd.contains(Os.OS_FAMILY == Os.FAMILY_WINDOWS ? "helm.exe repo" : "helm repo"))
+				.map(cmd -> cmd.substring(cmd.indexOf("repo add"))) //remove everything before repo add for easier verification
+				.collect(Collectors.toSet());
+
+		assertEquals(3, helmCommands.size(), "Expected 3 helm commands");
+		assertTrue(helmCommands.contains("repo add my-artifactory-stable https://somwhere.com/repo/stable"), "Adding upload stable repo expected");
+		assertTrue(helmCommands.contains("repo add my-artifactory-snapshot https://somwhere.com/repo/snapshot"), "Adding upload snapshot repo expected");
+		assertTrue(helmCommands.contains("repo add stable "+ InitMojo.STABLE_HELM_REPO), "Adding helm stable repo expected");
+	}
+
+	@Test
+	public void verifyAddingUploadSnapshotRepoStableNotPresent(InitMojo mojo) throws Exception {
+
+		// prepare execution
+		final HelmRepository helmUploadSnapshotRepo = new HelmRepository();
+		helmUploadSnapshotRepo.setType(RepoType.ARTIFACTORY);
+		helmUploadSnapshotRepo.setName("my-artifactory-snapshot");
+		helmUploadSnapshotRepo.setUrl("https://somwhere.com/repo/snapshot");
+		mojo.setUploadRepoSnapshot(helmUploadSnapshotRepo);
+		ArgumentCaptor<String> helmCommandCaptor = ArgumentCaptor.forClass(String.class);
+		doNothing().when(mojo).callCli(helmCommandCaptor.capture(), anyString(), anyBoolean());
+		mojo.setHelmDownloadUrl(getOsSpecificDownloadURL());
+		mojo.setAddDefaultRepo(false);
+		mojo.setAddUploadRepos(true);
+
+		// run init
+		mojo.execute();
+
+		// check captured commands
+		Set<String> helmCommands = helmCommandCaptor.getAllValues()
+				.stream()
+				.filter(cmd -> cmd.contains(Os.OS_FAMILY == Os.FAMILY_WINDOWS ? "helm.exe repo" : "helm repo"))
+				.map(cmd -> cmd.substring(cmd.indexOf("repo add"))) //remove everything before repo add for easier verification
+				.collect(Collectors.toSet());
+
+		assertEquals(1, helmCommands.size(), "Expected 1 helm command");
+		assertTrue(helmCommands.contains("repo add my-artifactory-snapshot https://somwhere.com/repo/snapshot"), "Adding upload snapshot repo expected");
+	}
+
+	@Test
+	public void verifyAddingUploadStableRepoSnapshotNotPresent(InitMojo mojo) throws Exception {
+
+		// prepare execution
+		final HelmRepository helmUploadStableRepo = new HelmRepository();
+		helmUploadStableRepo.setType(RepoType.ARTIFACTORY);
+		helmUploadStableRepo.setName("my-artifactory-stable");
+		helmUploadStableRepo.setUrl("https://somwhere.com/repo/stable");
+		mojo.setUploadRepoStable(helmUploadStableRepo);
+		ArgumentCaptor<String> helmCommandCaptor = ArgumentCaptor.forClass(String.class);
+		doNothing().when(mojo).callCli(helmCommandCaptor.capture(), anyString(), anyBoolean());
+		mojo.setHelmDownloadUrl(getOsSpecificDownloadURL());
+		mojo.setAddDefaultRepo(false);
+		mojo.setAddUploadRepos(true);
+
+		// run init
+		mojo.execute();
+
+		// check captured commands
+		Set<String> helmCommands = helmCommandCaptor.getAllValues()
+				.stream()
+				.filter(cmd -> cmd.contains(Os.OS_FAMILY == Os.FAMILY_WINDOWS ? "helm.exe repo" : "helm repo"))
+				.map(cmd -> cmd.substring(cmd.indexOf("repo add"))) //remove everything before repo add for easier verification
+				.collect(Collectors.toSet());
+
+		assertEquals(1, helmCommands.size(), "Expected 1 helm command");
+		assertTrue(helmCommands.contains("repo add my-artifactory-stable https://somwhere.com/repo/stable"), "Adding upload stable repo expected");
 	}
 
 	@Test
@@ -120,9 +294,9 @@ public class InitMojoTest {
 				.collect(Collectors.toList());
 		assertEquals(1, helmCommands.size(), "Only helm init command expected");
 		String helmDefaultCommand = helmCommands.get(0);
-		assertTrue(helmDefaultCommand.contains("--registry-config /path/to/my/registry.json"), "Option 'registry-config' not set");
-		assertTrue(helmDefaultCommand.contains("--repository-cache /path/to/my/repository/cache"), "Option 'repository-cache' not set");
-		assertTrue(helmDefaultCommand.contains("--repository-config /path/to/my/repositories.yaml"), "Option 'repository-config' not set");
+		assertTrue(helmDefaultCommand.contains("--registry-config=/path/to/my/registry.json"), "Option 'registry-config' not set");
+		assertTrue(helmDefaultCommand.contains("--repository-cache=/path/to/my/repository/cache"), "Option 'repository-cache' not set");
+		assertTrue(helmDefaultCommand.contains("--repository-config=/path/to/my/repositories.yaml"), "Option 'repository-config' not set");
 	}
 
 	@Test
@@ -168,6 +342,6 @@ public class InitMojoTest {
 	}
 
 	private String getOsSpecificDownloadURL(final String os) {
-		return "https://get.helm.sh/helm-v2.15.2-" + os + "-amd64." + ("windows".equals(os) ? "zip" : "tar.gz");
+		return "https://get.helm.sh/helm-v3.0.0-" + os + "-amd64." + ("windows".equals(os) ? "zip" : "tar.gz");
 	}
 }


### PR DESCRIPTION
### Reference issue: #109 
Helm upload repositories are not added as the repos for the dependency resolution

### Explanation of the implemented changes

InitMojo:
* Introduced a new property: **helm.init.add-upload-repos** with the default value **false**. If enabled, adds specified upload stable and snapshot repositories via 'helm add repo', for the chart dependency resolution when they are defined via an alias (repository name). In case both stable and snapshot repositories have the same names, only stable is added.
* code snippet for adding repositories is refactored to the separate method, and used for adding a default helm stable repo, upload repos and additional repos defined via helmExtraRepos.
* Small refactoring - stable helm repo URL refactored as a constant, to be used in the unit tests.

InitMojoTest:
* Added unit tests for adding each of the upload repos and the combination, also a negative test when the "add-upload-repo" is enabled but no upload repos defined, or only snapshot/stable defined, and a test when both the snapshot and stable repos have equal names
* Removed @EnabledOnOS(OS.LINUX) as tests aren't run on MacOS. I don't understand why this limitation - without it I can normally run tests on MacOS (Catalina). Tested also on Linux Mint 20.
* Updated getOsSpecificDownloadURL() method to download the Helm 3 binary for the OS 

README.md:
* added helm.init.add-upload-repos property to the table of the properties

Functionality also manually tested with a locally installed plugin snapshot.