### PR TITLE
Added install and template goals and addes upport for values in dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ and disables the auto-detection feature:
 - `helm:dependency-build` resolves the chart dependencies  
 - `helm:package` packages the given charts (chart.tar.gz)
 - `helm:lint` tests the given charts
+- `helm:template` Locally render templates
 - `helm:dry-run` simulates an install
 - `helm:upload` upload charts via HTTP PUT
 
@@ -268,10 +269,12 @@ Parameter | Type | User Property | Required | Description
 `<skip>` | boolean | helm.skip | false | skip plugin execution
 `<skipInit>` | boolean | helm.init.skip | false | skip init goal
 `<skipLint>` | boolean | helm.lint.skip | false | skip lint goal
+`<skipTemplate>` | boolean | helm.template.skip | false | skip template goal. Default value is true due to the dry-run goal
 `<skipDryRun>` | boolean | helm.dry-run.skip | false | skip dry-run goal
 `<skipDependencyBuild>` | boolean | helm.dependency-build.skip | false | skip dependency-build goal
 `<skipPackage>` | boolean | helm.package.skip | false | skip package goal
 `<skipUpload>` | boolean | helm.upload.skip | false | skip upload goal
+`<skipInstall>` | boolean | helm.install.skip | false | skip install goal
 `<security>` | string | helm.security | false | path to your [settings-security.xml](https://maven.apache.org/guides/mini/guide-encryption.html) (default: `~/.m2/settings-security.xml`)
 `<values>` | [ValueOverride](./src/main/java/com/kiwigrid/helm/maven/plugin/ValueOverride.java) | helm.values | false | override some values for linting with helm.values.overrides (--set option), helm.values.stringOverrides (--set-string option), helm.values.fileOverrides (--set-file option) and last but not least helm.values.yamlFile (--values option)
 

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
@@ -317,6 +317,13 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 		return securityDispatcher;
 	}
 
+	protected String formatIfValueIsNotEmpty(String format, String value) {
+		if (StringUtils.isNotEmpty(value)) {
+			return String.format(format, value);
+		}
+		return "";
+	}
+
 	public String getOutputDirectory() {
 		return outputDirectory;
 	}

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/DryRunMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/DryRunMojo.java
@@ -14,7 +14,7 @@ import org.codehaus.plexus.util.StringUtils;
  * @since 14.11.17
  */
 @Mojo(name = "dry-run", defaultPhase = LifecyclePhase.TEST)
-public class DryRunMojo extends AbstractHelmMojo {
+public class DryRunMojo extends AbstractHelmWithValueOverrideMojo {
 
 	@Parameter(property = "action", defaultValue = "install")
 	private String action;
@@ -35,7 +35,8 @@ public class DryRunMojo extends AbstractHelmMojo {
 					+ " --dry-run --generate-name"
 					+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
 					+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache() : "")
-					+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig() : ""),
+					+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig() : "")
+					+ getValuesOptions(),
 					"There are test failures", true);
 		}
 	}

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/InstallMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/InstallMojo.java
@@ -1,0 +1,56 @@
+package com.kiwigrid.helm.maven.plugin;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+
+/**
+ * Mojo for simulate a template.
+ *
+ * @author Tim IJntema
+ * @since 07.02.2021
+ */
+@Mojo(name = "install", defaultPhase = LifecyclePhase.DEPLOY)
+public class InstallMojo extends AbstractHelmWithValueOverrideMojo {
+
+	@Parameter(property = "action", defaultValue = "install")
+	private String action;
+
+	@Parameter(property = "helm.install.skip", defaultValue = "true")
+	private boolean skipInstall;
+
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (skip || skipInstall) {
+			getLog().info("Skip install");
+			return;
+		}
+		for (String inputDirectory : getChartDirectories(getChartDirectory())) {
+			getLog().info(String.format("\n\nPerform install for chart %s...", inputDirectory));
+
+			String clusterName = new File(inputDirectory).getName();
+
+			callCli(String.format("%s %s %s %s %s %s %s %s",
+					getHelmExecuteablePath(),
+					action,
+					formatIfValueIsNotEmpty("--registry-config=%s", getRegistryConfig()),
+					formatIfValueIsNotEmpty("--repository-cache=%s", getRepositoryCache()),
+					formatIfValueIsNotEmpty("--repository-config=%s", getRepositoryConfig()),
+					getValuesOptions(),
+					clusterName,
+					inputDirectory),
+					"Failed to deploy helm chart", true);
+		}
+	}
+
+	public String getAction() {
+		return action;
+	}
+
+	public void setAction(String action) {
+		this.action = action;
+	}
+}

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/InstallMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/InstallMojo.java
@@ -36,12 +36,12 @@ public class InstallMojo extends AbstractHelmWithValueOverrideMojo {
 			callCli(String.format("%s %s %s %s %s %s %s %s",
 					getHelmExecuteablePath(),
 					action,
+					clusterName,
+					inputDirectory,
 					formatIfValueIsNotEmpty("--registry-config=%s", getRegistryConfig()),
 					formatIfValueIsNotEmpty("--repository-cache=%s", getRepositoryCache()),
 					formatIfValueIsNotEmpty("--repository-config=%s", getRepositoryConfig()),
-					getValuesOptions(),
-					clusterName,
-					inputDirectory),
+					getValuesOptions()),
 					"Failed to deploy helm chart", true);
 		}
 	}

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/TemplateMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/TemplateMojo.java
@@ -6,8 +6,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import java.io.File;
-
 /**
  * Mojo for simulate a template.
  *

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/TemplateMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/TemplateMojo.java
@@ -1,0 +1,53 @@
+package com.kiwigrid.helm.maven.plugin;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+
+/**
+ * Mojo for simulate a template.
+ *
+ * @author Tim IJntema
+ * @since 07.02.2021
+ */
+@Mojo(name = "template", defaultPhase = LifecyclePhase.TEST)
+public class TemplateMojo extends AbstractHelmWithValueOverrideMojo {
+
+	@Parameter(property = "action", defaultValue = "template")
+	private String action;
+
+	@Parameter(property = "helm.template.skip", defaultValue = "true")
+	private boolean skipTemplate;
+
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (skip || skipTemplate) {
+			getLog().info("Skip template");
+			return;
+		}
+		for (String inputDirectory : getChartDirectories(getChartDirectory())) {
+			getLog().info(String.format("\n\nPerform template for chart %s...", inputDirectory));
+
+			callCli(String.format("%s %s %s %s %s %s %s",
+					getHelmExecuteablePath(),
+					action,
+					inputDirectory,
+					formatIfValueIsNotEmpty("--registry-config=%s", getRegistryConfig()),
+					formatIfValueIsNotEmpty("--repository-cache=%s", getRepositoryCache()),
+					formatIfValueIsNotEmpty("--repository-config=%s", getRepositoryConfig()),
+					getValuesOptions()),
+					"There are test failures", true);
+		}
+	}
+
+	public String getAction() {
+		return action;
+	}
+
+	public void setAction(String action) {
+		this.action = action;
+	}
+}

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojoTest.java
@@ -81,6 +81,20 @@ class AbstractHelmMojoTest {
         assertFalse(chartDirectories.contains(excludeDir2), "Charts dirs [" + chartDirectories + "] should not contain excluded dirs [" + excludeDir2 + "]");
     }
 
+    @Test
+    void formatIfValueIsNotEmpty() {
+        String formatString = "Test %s data";
+        String value = "format";
+
+        String formatWithValue = subjectSpy.formatIfValueIsNotEmpty(formatString, value);
+        String formatWithNullValue = subjectSpy.formatIfValueIsNotEmpty(formatString, null);
+        String formatWithEmptyValue = subjectSpy.formatIfValueIsNotEmpty(formatString, "");
+
+        assertEquals("Test format data", formatWithValue);
+        assertEquals("", formatWithNullValue);
+        assertEquals("", formatWithEmptyValue);
+    }
+
     @Nested
     class WhenUseLocalBinaryAndAutoDetectIsEnabled {
 


### PR DESCRIPTION
Fixes #86 

This change adds the following goals:

- helm:install (with support for values)
- helm:template (with support for values)

The following existing goal has been updated:
- helm:dry-run - values can now be provided