### PR TITLE
nexus authentication from settings.xml

### DIFF
--- a/src/main/java/com/kiwigrid/helm/maven/plugin/UploadMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/UploadMojo.java
@@ -171,7 +171,7 @@ public class UploadMojo extends AbstractHelmMojo {
 					return authentication;
 				}
 			});
-		}else if (requireCredentials) {
+		} else if (requireCredentials) {
 			throw new IllegalArgumentException("Credentials has to be configured for uploading to Artifactory.");
 		}
 


### PR DESCRIPTION
**feature** 
upload to nexus does not use username/pwd from settings.xml file #105

**changes** 
- Nexus connection now uses the exsiting implemented authentication method used for artifactory. 
- Added a parameter to verifyAndSetAuthentication because nexus can be configured without authentication and that method was throwning exception if there were no credentials configured at all. I have no experience with artifactory so the decision was to mantain the existing behaviour of exception without artifactory credentials.

**additional notes**
This implementation can be extended to chartmuseum also and remove the setBasicAuthHeader method altogether.
