### PR TITLE
fix(io): avoid blocking IO in callCli()

### DIFF
--- a/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
@@ -158,9 +158,7 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 			final Process p = Runtime.getRuntime().exec(command);
 			new Thread(() -> {
 				BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()));
-				BufferedReader error = new BufferedReader(new InputStreamReader(p.getErrorStream()));
 				String inputLine;
-				String errorLine;
 				try {
 					while ((inputLine = input.readLine()) != null) {
 						if (verbose) {
@@ -169,6 +167,14 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 							getLog().debug(inputLine);
 						}
 					}
+				} catch (IOException e) {
+					getLog().error(e);
+				}
+			}).start();
+			new Thread(() -> {
+				BufferedReader error = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+				String errorLine;
+				try {
 					while ((errorLine = error.readLine()) != null) {
 						getLog().error(errorLine);
 					}


### PR DESCRIPTION
Fixes #117

I'm sure there's more than one way to skin this cat (use of ready(), NIO, etc.) though this solves the immediate problem and fits the current code style.

Ensure stderr doesn't starve waiting for stdout.