### PR TITLE
Timestamp as version on SNAPSHOTs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         if: failure()
         with:
           name: surefire
-          path: '*/target/surefire-reports/*.xml'
+          path: '**/target/surefire-reports/*.xml'
           reporter: java-junit
           list-suites: failed
           list-tests: failed

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -39,7 +39,7 @@ jobs:
         if: failure()
         with:
           name: surefire
-          path: '*/target/surefire-reports/*.xml'
+          path: '**/target/surefire-reports/*.xml'
           reporter: java-junit
           list-suites: failed
           list-tests: failed

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/AbstractHelmMojo.java
@@ -1,6 +1,7 @@
 package com.kiwigrid.helm.maven.plugin;
 
 import com.kiwigrid.helm.maven.plugin.pojo.HelmRepository;
+import com.kiwigrid.helm.maven.plugin.pojo.K8SCluster;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.plugin.AbstractMojo;
@@ -15,18 +16,16 @@ import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.PasswordAuthentication;
-
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -35,8 +34,6 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import com.kiwigrid.helm.maven.plugin.pojo.K8SCluster;
 
 
 /**
@@ -70,6 +67,12 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 
 	@Parameter(property = "helm.chartVersion")
 	private String chartVersion;
+
+	@Parameter(property = "helm.chartVersion.timestampOnSnapshot")
+	private boolean timestampOnSnapshot;
+
+	@Parameter(property = "helm.chartVersion.timestampFormat", defaultValue = "yyyyMMddHHmmss")
+	private String timestampFormat;
 
 	@Parameter(property = "helm.appVersion")
 	private String appVersion;
@@ -115,11 +118,13 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${settings}", readonly = true)
 	private Settings settings;
 
-	@Parameter( defaultValue="${project.groupId}", readonly=true)
+	@Parameter(defaultValue="${project.groupId}", readonly=true)
 	String projectGroupId;
 
-	@Parameter( defaultValue="${project.version}", readonly=true)
+	@Parameter(defaultValue="${project.version}", readonly=true)
 	String projectVersion;
+
+	private Clock clock = Clock.systemDefaultZone();
 
 	Path getHelmExecuteablePath() throws MojoExecutionException {
 		String helmExecutable = SystemUtils.IS_OS_WINDOWS ? "helm.exe" : "helm";
@@ -157,6 +162,11 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 		return System.getenv("PATH").split(Pattern.quote(File.pathSeparator));
 	}
 
+	String getCurrentTimestamp(){
+		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(getTimestampFormat());
+		LocalDateTime currentTime = LocalDateTime.now(clock);
+		return dateTimeFormatter.format(currentTime);
+	}
 
 	/**
 	 * Calls cli with specified command
@@ -467,6 +477,9 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 	}
 
 	public String getChartVersion() {
+		if (isTimestampOnSnapshot() && chartVersion.endsWith("-SNAPSHOT")) {
+			return chartVersion.replace("SNAPSHOT", getCurrentTimestamp());
+		}
 		return chartVersion;
 	}
 
@@ -556,5 +569,21 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 
 	public void setProjectVersion(String projectVersion) {
 		this.projectVersion = projectVersion;
+	}
+
+	public boolean isTimestampOnSnapshot() {
+		return timestampOnSnapshot;
+	}
+
+	public void setTimestampOnSnapshot(boolean timestampOnSnapshot) {
+		this.timestampOnSnapshot = timestampOnSnapshot;
+	}
+
+	public String getTimestampFormat() {
+		return timestampFormat;
+	}
+
+	public void setTimestampFormat(String timestampFormat) {
+		this.timestampFormat = timestampFormat;
 	}
 }

--- a/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
+++ b/src/main/java/com/kiwigrid/helm/maven/plugin/InitMojo.java
@@ -191,7 +191,7 @@ public class InitMojo extends AbstractHelmMojo {
 		} 
 
 		if (!found) {
-			throw new MojoExecutionException("Unable to find helm executable in tar file.");
+			throw new MojoExecutionException("Unable to find helm executable in archive.");
 		}
 	}
 

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
@@ -46,7 +46,7 @@ public class InitMojoTest {
 		doNothing().when(mojo).callCli(contains("helm "), anyString(), anyBoolean());
 		// getHelmExecuteablePath is system-depending and has to be mocked for that reason
 		// as SystemUtils.IS_OS_WINDOWS will always return false on a *NIX system
-		doReturn(Paths.get("dummy/path/to/helm").toAbsolutePath()).when(mojo).getHelmExecuteablePath();
+//		doReturn(Paths.get("dummy/path/to/helm").toAbsolutePath()).when(mojo).getHelmExecuteablePath();
 		mojo.setHelmDownloadUrl(getOsSpecificDownloadURL(os));
 
 		// run init

--- a/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
+++ b/src/test/java/com/kiwigrid/helm/maven/plugin/InitMojoTest.java
@@ -1,15 +1,5 @@
 package com.kiwigrid.helm.maven.plugin;
 
-import java.io.File;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.kiwigrid.helm.maven.plugin.junit.MojoExtension;
 import com.kiwigrid.helm.maven.plugin.junit.MojoProperty;
 import com.kiwigrid.helm.maven.plugin.junit.SystemPropertyExtension;
@@ -19,12 +9,20 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.Os;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -36,6 +34,7 @@ import static org.mockito.Mockito.doReturn;
 @MojoProperty(name = "helmDownloadUrl", value = "https://get.helm.sh/helm-v3.0.0-linux-amd64.tar.gz")
 @MojoProperty(name = "chartDirectory", value = "junit-helm")
 @MojoProperty(name = "chartVersion", value = "0.0.1")
+@MojoProperty(name = "helmExecutableDirectory", value = "target/helm")
 public class InitMojoTest {
 
 	@DisplayName("Init helm with different download urls.")
@@ -65,9 +64,6 @@ public class InitMojoTest {
 
 		// prepare execution
 		doNothing().when(mojo).callCli(contains("helm "), anyString(), anyBoolean());
-		// getHelmExecuteablePath is system-depending and has to be mocked for that reason
-		// as SystemUtils.IS_OS_WINDOWS will always return false on a *NIX system
-		doReturn(Paths.get("dummy/path/to/helm").toAbsolutePath()).when(mojo).getHelmExecuteablePath();
 		mojo.setHelmDownloadUrl(null);
 		mojo.setHelmVersion("3.2.0");
 


### PR DESCRIPTION
To follow SemVer2. 
While uploading to Artifactory repo it is impossible to override already deployed version - hence need to follow maven approach. Once SNAPSHOT - replace "SNAPSHOT" with timestamp. 